### PR TITLE
Add setup script for environment configuration

### DIFF
--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_VARS=(
+  ICEBERG_REST_URI
+  ICEBERG_CATALOG_TOKEN
+  ICEBERG_WAREHOUSE
+  S3_ENDPOINT
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+)
+
+missing=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Error: missing required environment variables:" >&2
+  for var in "${missing[@]}"; do
+    echo "  - $var" >&2
+  done
+  exit 1
+fi
+
+ENV_FILE="$(dirname "$0")/.env"
+
+{
+  for var in "${REQUIRED_VARS[@]}"; do
+    echo "${var}=${!var}"
+  done
+} > "$ENV_FILE"
+
+echo "Written to $ENV_FILE"


### PR DESCRIPTION
## Summary
Add a new setup script that validates and exports required environment variables to a `.env` file for local development.

## Key Changes
- Created `.claude/setup.sh` - a bash script that:
  - Validates the presence of 6 required environment variables (Iceberg REST API credentials, S3 configuration, and AWS credentials)
  - Reports all missing variables at once with clear error messaging
  - Generates a `.env` file in the `.claude/` directory with the validated variables
  - Uses strict bash settings (`set -euo pipefail`) for safety

## Implementation Details
- The script checks for required variables: `ICEBERG_REST_URI`, `ICEBERG_CATALOG_TOKEN`, `ICEBERG_WAREHOUSE`, `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`
- Exits with status code 1 if any required variables are missing
- Outputs the generated `.env` file path on success for user confirmation
- Uses parameter expansion `${!var:-}` to safely check variable existence

https://claude.ai/code/session_01KB47UZvYHfmpGKB3cNMoUo