### PR TITLE
Refactor CLI commands for model operations

### DIFF
--- a/dbport.lock
+++ b/dbport.lock
@@ -55,10 +55,10 @@ completed = true
 
 [[models."test.table1".versions]]
 version = "2026-03-14"
-published_at = 2026-03-14T12:12:48Z
-iceberg_snapshot_id = 8487503688100859175
-iceberg_snapshot_timestamp = 2026-03-14T12:12:47.609000Z
-rows = 1485615
+published_at = 2026-03-16T17:47:20Z
+iceberg_snapshot_id = 8472677153308947283
+iceberg_snapshot_timestamp = 2026-03-16T17:47:19.716000Z
+rows = 500555
 completed = true
 
 [models."test.cli_table1"]
@@ -66,6 +66,7 @@ agency = "test"
 dataset_id = "cli_table1"
 model_root = "examples/minimal_cli"
 duckdb_path = "examples/minimal_cli/data/cli_table1.duckdb"
+run_hook = "sql/main.sql"
 
 [models."test.cli_table1".schema]
 ddl = "CREATE SCHEMA IF NOT EXISTS test;\n\nCREATE OR REPLACE TABLE test.cli_table1 (\n    geo    VARCHAR NOT NULL,\n    year   INTEGER NOT NULL,\n    value  DOUBLE\n);"
@@ -91,9 +92,9 @@ codelist_id = "value"
 
 [[models."test.cli_table1".inputs]]
 table_address = "test.table1"
-last_snapshot_id = 8351008129908343306
-last_snapshot_timestamp_ms = 1773501203957
-rows_loaded = 1485615
+last_snapshot_id = 8472677153308947283
+rows_loaded = 500555
+version = "2026-03-14"
 
 [[models."test.cli_table1".inputs]]
 table_address = "estat.nama_10r_3empers"
@@ -103,8 +104,8 @@ rows_loaded = 1485951
 
 [[models."test.cli_table1".versions]]
 version = "2026-03-15"
-published_at = 2026-03-15T12:45:54Z
-iceberg_snapshot_id = 5459699385693949521
-iceberg_snapshot_timestamp = 2026-03-15T12:45:53.300000Z
+published_at = 2026-03-16T17:49:20Z
+iceberg_snapshot_id = 7237874022855053417
+iceberg_snapshot_timestamp = 2026-03-16T17:49:20.150000Z
 rows = 1485615
 completed = true

--- a/docs/dbport_cli.md
+++ b/docs/dbport_cli.md
@@ -9,12 +9,12 @@ DBPort is not meant to feel like a Python library that users wire together manua
 The Python client remains the runtime engine, but the CLI is the primary user interface.
 
 That means:
-	•	users should be able to initialize and operate DBPort projects from the CLI
-	•	users should configure the project primarily through CLI actions
-	•	configuration changes should persist automatically
-	•	operational state should be visible and inspectable
-	•	recompute should be a first-class production workflow
-	•	Python usage should remain available, but as an advanced or embedded interface
+ • users should be able to initialize and operate DBPort projects from the CLI
+ • users should configure the project primarily through CLI actions
+ • configuration changes should persist automatically
+ • operational state should be visible and inspectable
+ • recompute should be a first-class production workflow
+ • Python usage should remain available, but as an advanced or embedded interface
 
 ⸻
 
@@ -27,23 +27,23 @@ DBPort CLI is the operational interface for building and running reproducible Du
 What it does
 
 The CLI gives users a single surface to:
-	•	initialize a DBPort project
-	•	define and persist dataset configuration
-	•	resolve and load inputs
-	•	run model logic
-	•	validate outputs
-	•	publish datasets
-	•	inspect and manage project configuration
-	•	perform conditional recomputes
+ • initialize a DBPort project
+ • define and persist dataset configuration
+ • resolve and load inputs
+ • run model logic
+ • validate outputs
+ • publish datasets
+ • inspect and manage project configuration
+ • perform conditional recomputes
 
 What it does not try to be
 
 The CLI is not:
-	•	a generic ETL shell
-	•	a workflow orchestrator
-	•	a replacement for dbt
-	•	a replacement for Python for model logic
-	•	a general configuration framework
+ • a generic ETL shell
+ • a workflow orchestrator
+ • a replacement for dbt
+ • a replacement for Python for model logic
+ • a general configuration framework
 
 Instead, it is the default operational shell around the DBPort runtime.
 
@@ -54,23 +54,24 @@ Default Usage Model
 Default mode: CLI-first
 
 The default intended experience is:
-	1.	install DBPort
-	2.	create a model/project with the CLI
-	3.	define configuration through CLI commands
-	4.	persist that configuration automatically
-	5.	run and publish through CLI commands
-	6.	use Python only when writing custom model logic or embedding DBPort programmatically
+
+ 1. install DBPort
+ 2. create a model/project with the CLI
+ 3. define configuration through CLI commands
+ 4. persist that configuration automatically
+ 5. run and publish through CLI commands
+ 6. use Python only when writing custom model logic or embedding DBPort programmatically
 
 Runtime model: client underneath
 
 The Python client remains responsible for the core lifecycle:
-	•	schema handling
-	•	input loading
-	•	execution
-	•	validation support
-	•	publish semantics
-	•	lock/state handling
-	•	recompute planning
+ • schema handling
+ • input loading
+ • execution
+ • validation support
+ • publish semantics
+ • lock/state handling
+ • recompute planning
 
 So the correct mental model is:
 
@@ -87,12 +88,12 @@ By default, configuration should be made via the CLI.
 Users should not be expected to hand-edit configuration files for normal operation.
 
 Examples:
-	•	adding or changing a dataset binding
-	•	setting the output dataset ID
-	•	selecting a default model
-	•	setting publish defaults
-	•	configuring input aliases
-	•	storing resolved runtime state
+ • adding or changing a dataset binding
+ • setting the output dataset ID
+ • selecting a default model
+ • setting publish defaults
+ • configuring input aliases
+ • storing resolved runtime state
 
 All of these should be done through CLI commands and then persisted automatically.
 
@@ -105,52 +106,52 @@ dbport.lock
 This file is the canonical persisted state of the project and model workflow.
 
 It contains:
-	•	default model selection
-	•	per-model identity (agency, dataset_id, model_root, duckdb_path)
-	•	resolved inputs with snapshot IDs and timestamps
-	•	output schema state (DDL, columns, codelist metadata)
-	•	publish history (versions, timestamps, row counts)
-	•	recompute state (future)
+ • default model selection
+ • per-model identity (agency, dataset_id, model_root, duckdb_path)
+ • resolved inputs with snapshot IDs and timestamps
+ • output schema state (DDL, columns, codelist metadata)
+ • publish history (versions, timestamps, row counts)
+ • recompute state (future)
 
 The lock file is TOML, safe to commit, and contains no secrets.
 
 Optional static configuration
 
 Users may optionally place static configuration in:
-	•	pyproject.toml
-	•	dbport.toml
+ • pyproject.toml
+ • dbport.toml
 
 These are optional sources for defaults and declarative project setup.
 
 Intended role of pyproject.toml
 
 Use for:
-	•	package metadata
-	•	dependency declarations
-	•	console script registration
-	•	repo-level DBPort defaults if the project already uses pyproject.toml
+ • package metadata
+ • dependency declarations
+ • console script registration
+ • repo-level DBPort defaults if the project already uses pyproject.toml
 
 Intended role of dbport.toml
 
 Use for:
-	•	explicit DBPort project/model configuration in TOML form
-	•	teams who want a dedicated config file
-	•	static checked-in defaults
+ • explicit DBPort project/model configuration in TOML form
+ • teams who want a dedicated config file
+ • static checked-in defaults
 
 Important rule
 
 By default:
-	•	CLI writes config/state
-	•	lock file persists runtime truth
-	•	TOML config is optional, not required
+ • CLI writes config/state
+ • lock file persists runtime truth
+ • TOML config is optional, not required
 
 Configuration precedence
 
-	1.	CLI flags
-	2.	persisted runtime state in dbport.lock
-	3.	dbport.toml
-	4.	pyproject.toml
-	5.	built-in defaults
+ 1. CLI flags
+ 2. persisted runtime state in dbport.lock
+ 3. dbport.toml
+ 4. pyproject.toml
+ 5. built-in defaults
 
 That gives the CLI clear authority while still allowing static project defaults.
 
@@ -159,18 +160,18 @@ That gives the CLI clear authority while still allowing static project defaults.
 Why the CLI is the default
 
 DBPort is a product for:
-	•	governed input/output handling
-	•	reproducible dataset production
-	•	safe publication
-	•	inspectable runtime state
-	•	periodic recomputes
+ • governed input/output handling
+ • reproducible dataset production
+ • safe publication
+ • inspectable runtime state
+ • periodic recomputes
 
 Those are operational concerns, and operational concerns are best expressed through a CLI.
 
 A CLI-first interface makes DBPort feel like:
-	•	a coherent product
-	•	a repeatable workflow
-	•	a standardizable production tool
+ • a coherent product
+ • a repeatable workflow
+ • a standardizable production tool
 
 ⸻
 
@@ -180,23 +181,23 @@ CLI Product Principles
 
 The CLI should stay small and memorable.
 
-2. Mirrors the runtime
+1. Mirrors the runtime
 
 Command names should align closely with core client concepts.
 
-3. Safe and inspectable
+1. Safe and inspectable
 
 Every important state transition should be visible.
 
-4. Configuration through commands
+1. Configuration through commands
 
 Users should configure the system by using it, not by editing files.
 
-5. Recompute is first-class
+1. Recompute is first-class
 
 Periodic reruns are a core production behavior, not an afterthought.
 
-6. Human-first, scriptable second
+1. Human-first, scriptable second
 
 Use Rich for interactive clarity and --json for automation.
 
@@ -208,13 +209,20 @@ Command surface
 
 dbp init
 dbp status
-dbp check
-dbp schema
-dbp load
-dbp run
-dbp publish
-dbp config default
-dbp config info
+dbp status check
+dbp model sync
+dbp model load
+dbp model exec
+dbp model publish
+dbp model run
+dbp project sync
+dbp project load
+dbp project exec
+dbp project publish
+dbp project run
+dbp config default model
+dbp config model
+dbp config model input
 dbp validate          (planned)
 dbp recompute         (planned)
 
@@ -242,11 +250,11 @@ Model Resolution
 
 When a command needs to resolve which model to operate on, the following precedence applies:
 
-	1.	Positional MODEL argument — explicit model key (agency.dataset_id), supported by dbp run, dbp publish, and dbp init
-	2.	--model flag — explicit model directory relative to project root
-	3.	CWD matching — current working directory relative to repo root, matched against model_root entries in the lock
-	4.	default_model — persisted in dbport.lock, set automatically on dbp init and changeable via dbp config default
-	5.	First model — fallback for single-model repos or when running from the repo root
+ 1. Positional MODEL argument — explicit model key (agency.dataset_id), supported by dbp model sync|load|exec|publish|run and dbp init
+ 2. --model flag — explicit model directory relative to project root
+ 3. CWD matching — current working directory relative to repo root, matched against model_root entries in the lock
+ 4. default_model — persisted in dbport.lock, set automatically on dbp init and changeable via dbp config default model
+ 5. First model — fallback for single-model repos or when running from the repo root
 
 ⸻
 
@@ -254,9 +262,9 @@ Command-by-command reference
 
 dbp init
 
-Initialize or sync models.
+Initialize a new model scaffold.
 
-This command has two modes: it either **syncs existing models** from the lock file or **scaffolds a new model** and registers it. The mode is determined automatically based on whether the given name or agency/dataset combination matches an existing model in `dbport.lock`.
+`dbp init` is now scaffold-only. It creates a new model directory, registers it in `dbport.lock`, and fails fast if the target model already exists. Operational lifecycle work has moved to the `dbp model ...` and `dbp project ...` command groups.
 
 Interface
 
@@ -264,7 +272,7 @@ dbp init [NAME]
 
 Arguments
 
-NAME              Model key (agency.dataset_id) to sync, or new project name to scaffold
+NAME              New project/model name to scaffold
 
 Flags
 
@@ -274,41 +282,28 @@ Flags
 --path PATH       Target directory (default: ./<NAME>)
 --force           Overwrite existing files
 
-Behavior: sync vs scaffold
+Behavior
+ • Creates a directory scaffold with starter SQL templates
+ • Registers the model in the repo-root dbport.lock under [models."agency.dataset_id"]
+ • Sets the newly initialized model as the default (every init updates the default)
+ • model_root and duckdb_path are stored as paths relative to the repo root
+ • Does NOT connect to the warehouse (offline operation)
+ • If the model key already exists, exits with an error and directs the user to `dbp model sync` or `dbp project sync`
 
-The command resolves what to do based on the arguments:
-
-	•	No arguments — syncs all models in the lock file, running them in parallel
-	•	Model key that exists in lock (e.g. `test.table1`) — syncs that specific model
-	•	`--agency` + `--dataset` matching an existing model — syncs that model
-	•	Name or agency/dataset not in lock — scaffolds a new model
-
-Sync mode
-	•	Creates a DBPort instance for each model, triggering the init-time sync (schema detection, local state reconciliation)
-	•	Multiple models run in parallel using a thread pool (up to 4 concurrent workers)
-	•	Progress is displayed as a Rich tree where each model is a parent node and sync steps are children (see Progress Display below)
-
-Scaffold mode (new models)
-	•	Creates a directory scaffold with starter SQL templates
-	•	Registers the model in the repo-root dbport.lock under [models."agency.dataset_id"]
-	•	Sets the newly initialized model as the default (every init updates the default)
-	•	model_root and duckdb_path are stored as paths relative to the repo root
-	•	Does NOT connect to the warehouse (offline operation)
+Scaffold contents
+ • Creates a directory scaffold with starter SQL templates
 
 What scaffold creates
 
 <target>/
+ main.py                Default Python run hook exposing `run(port)` for CLI use
   sql/
     create_output.sql     DDL template
     main.sql              Transform template
   data/                   DuckDB data directory
-  run.py                  Only for python/hybrid templates
 
 Example usage
 
-dbp init                                    # sync all models in lock file
-dbp init test.table1                        # sync a specific existing model
-dbp init --agency test --dataset table1     # sync by agency + dataset
 dbp init regional_trends --template hybrid --dataset emp__regional_trends --agency wifor  # scaffold new
 dbp init --agency wifor --dataset emp_test --path examples/emp_test                       # scaffold new
 
@@ -329,13 +324,13 @@ Flags
 --show-history    Show version publish history table
 
 What it shows
-	•	project root and lockfile path
-	•	for each model in the lock file:
-	  •	agency, dataset ID, model root, DuckDB path
-	  •	schema state (defined or not, column count)
-	  •	loaded inputs (table addresses, row counts)
-	  •	published versions (count, latest version)
-	  •	optional version history table (with --show-history)
+ • project root and lockfile path
+ • for each model in the lock file:
+   • agency, dataset ID, model root, DuckDB path
+   • schema state (defined or not, column count)
+   • loaded inputs (table addresses, row counts)
+   • published versions (count, latest version)
+   • optional version history table (with --show-history)
 
 Example usage
 
@@ -345,43 +340,45 @@ dbp status --show-history
 
 ⸻
 
-dbp check
+dbp status check
 
 Check whether the project is operationally healthy.
 
 Interface
 
-dbp check
+dbp status check
 
 Flags
 
 --strict          Fail on warnings
 
 Checks performed
-	•	lockfile — dbport.lock exists
-	•	lockfile_readable — valid TOML
-	•	duckdb — DuckDB can be imported and run
-	•	credentials — required env vars present (ICEBERG_REST_URI, ICEBERG_CATALOG_TOKEN, ICEBERG_WAREHOUSE)
-	•	dependencies — pyarrow, pyiceberg, pydantic installed
+ • lockfile — dbport.lock exists
+ • lockfile_readable — valid TOML
+ • duckdb — DuckDB can be imported and run
+ • credentials — required env vars present (ICEBERG_REST_URI, ICEBERG_CATALOG_TOKEN, ICEBERG_WAREHOUSE)
+ • dependencies — pyarrow, pyiceberg, pydantic installed
 
 Each check produces pass, warn, or fail. In --strict mode, any warning becomes a failure.
 
 Example usage
 
-dbp check
-dbp check --strict
+dbp status check
+dbp status check --strict
 
 ⸻
 
-dbp schema
+dbp config model MODEL_KEY schema
 
-Show or apply the output schema contract.
+Show or apply the output schema contract for a specific model.
 
 Interface
 
-dbp schema [SOURCE]
+dbp config model MODEL_KEY schema [SOURCE]
 
 Arguments
+
+MODEL_KEY         Model key (agency.dataset_id)
 
 SOURCE            Path to .sql DDL file to apply (relative to model root)
 
@@ -390,129 +387,124 @@ Flags
 --diff            Show schema diff between lock and DuckDB
 
 Behavior
-	•	no argument: show current schema from lock file (columns table + DDL)
-	•	with path argument: apply schema from SQL file via port.schema()
-	•	source path is resolved relative to the model root directory
+ • no argument: show current schema from lock file (columns table + DDL)
+ • with path argument: apply schema from SQL file via port.schema()
+ • source path is resolved relative to the model root directory
 
 Example usage
 
-dbp schema
-dbp schema sql/create_output.sql
-dbp schema --diff
-dbp schema --json
+dbp config model wifor.emp__regional_trends schema
+dbp config model wifor.emp__regional_trends schema sql/create_output.sql
+dbp config model wifor.emp__regional_trends schema --diff
+dbp config model wifor.emp__regional_trends schema --json
 
 ⸻
 
-dbp load
+dbp config model MODEL_KEY input
 
-Load configured or explicit inputs into DuckDB.
+Inspect or configure model inputs.
 
 Interface
 
-dbp load [DATASET]
+dbp config model MODEL_KEY input [DATASET]
 
 Arguments
 
-DATASET           Table address to load (e.g. estat.table_name)
+MODEL_KEY         Model key (agency.dataset_id)
+DATASET           Table address to add as an input (e.g. estat.table_name)
 
 Flags
 
---refresh         Force re-load even if snapshot unchanged
+--filter TEXT     Repeatable key=value filter applied to the input declaration
+--version TEXT    Optional source version to persist with the input declaration
+--load            Load the configured input immediately after persisting it
 
 Behavior
-	•	with argument: load one explicit input table
-	•	without argument: load all configured inputs from lock file (reads table_address, filters, and version from each input record)
+ • without DATASET: show configured inputs for the model
+ • with DATASET: persist a new input declaration into dbport.lock
+ • by default, only update configuration; loading is explicit
+ • with `--load`, persist the declaration and then load that configured input on demand
 
 Example usage
 
-dbp load
-dbp load estat.nama_10r_3empers
-dbp load --refresh
+dbp config model wifor.emp__regional_trends input
+dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers
+dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers --filter wstatus=EMP
+dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers --version 2026-03-01 --load
 
 ⸻
 
-dbp run
+dbp model sync | load | exec | publish | run
 
-Run the complete model workflow: sync, execute, and optionally publish.
+Run lifecycle operations for one resolved model.
 
-This is the primary command for running a model end-to-end. It performs the full lifecycle in a single invocation: initializes (syncs) the model, executes the configured run hook, and optionally publishes the result.
+These commands default to the resolved model when no explicit model key is supplied. They are the model-scoped operational surface of the CLI.
 
 Interface
 
-dbp run [MODEL]
+dbp model sync [MODEL]
+dbp model load [MODEL] [--update]
+dbp model exec [MODEL] [--target PATH] [--timing]
+dbp model publish [MODEL] [--version TEXT] [--dry-run] [--refresh] [--message TEXT]
+dbp model run [MODEL] [--version TEXT] [--target PATH] [--timing] [--dry-run] [--refresh]
 
 Arguments
 
-MODEL             Model key (agency.dataset_id) to run. Optional — falls back to model resolution (see Model Resolution above).
-
-Flags
-
---version TEXT     Version to publish after execution
---timing          Print execution duration
---dry-run         Validate only; do not publish
---refresh         Overwrite existing version
+MODEL             Model key (agency.dataset_id). Optional — falls back to model resolution (see Model Resolution above).
 
 Behavior
-	•	Resolves the model from the positional argument or default model resolution
-	•	Creates a DBPort instance, triggering init-time sync (schema detection, input loading)
-	•	Reads the run_hook from the lock file and executes it via port.execute()
-	•	If --version is provided, publishes after execution
-	•	If --refresh or --dry-run is used without --version, falls back to the latest completed version from the lock file
-	•	Progress is displayed as a Rich tree (same renderer as dbp init) with sync steps, execution, and publish as child nodes
+ • `dbp model sync` opens the model via DBPort and performs init-time sync only
+ • `dbp model load` loads the inputs already configured in `dbport.lock`
+ • `dbp model load --update` resolves the newest available snapshot for each configured input and updates the lock state
+ • `dbp model exec` runs the configured hook, or `--target` to override it for a one-off execution
+ • `dbp model publish` publishes one model, resolving the version from `--version` or the latest completed lock entry
+ • `dbp model run` performs sync, execution, and publish in one command
+ • `dbp model run` resolves the version from `--version`, configured model version, or latest completed version
 
 Example usage
 
-dbp run                                       # run default model
-dbp run test.table1                           # run specific model
-dbp run --version 2026-03-15                  # run and publish
-dbp run test.table1 --version 2026-03-15      # run specific model and publish
-dbp run --refresh                             # run and overwrite latest version
-dbp run --timing                              # show execution duration
+dbp model sync
+dbp model sync test.table1
+dbp model load
+dbp model load test.table1 --update
+dbp model exec --target sql/transform.sql
+dbp model exec test.table1 --timing
+dbp model publish --version 2026-03-15
+dbp model publish test.table1 --refresh
+dbp model run --version 2026-03-15 --timing
+dbp model run test.table1 --target sql/main.sql --dry-run
 
 ⸻
 
-dbp publish
+dbp project sync | load | exec | publish | run
 
-Publish the current output dataset to the warehouse.
+Run lifecycle operations across every model in the lock file.
 
 Interface
 
-dbp publish [MODEL]
+dbp project sync
+dbp project load [--update]
+dbp project exec [--target PATH]
+dbp project publish [--version TEXT] [--dry-run] [--refresh] [--message TEXT]
+dbp project run [--version TEXT] [--target PATH] [--dry-run] [--refresh]
 
-Arguments
-
-MODEL             Model key (agency.dataset_id) to publish. Optional — falls back to model resolution (see Model Resolution above).
-
-Flags
-
---version TEXT     Version identifier (e.g. "2026-03-15"). Optional — falls back to the latest completed version in the lock file.
---dry-run          Validate only; do not write data (mode="dry")
---refresh          Overwrite existing version (mode="refresh")
---message TEXT     Publish note for history
---yes, -y          Skip confirmation prompt
---strict           Fail on warnings
-
-Publish modes
-	•	default (no flag): idempotent — skip if version already completed
-	•	--dry-run: schema validation only, no data written
-	•	--refresh: overwrite existing version unconditionally
-
-Version resolution
-
-When --version is not provided, the command reads the lock file and uses the latest completed version. This enables patterns like `dbp publish --refresh` to overwrite the latest version of the default model without specifying the version explicitly. If no completed versions exist in the lock, the command fails with a clear error.
-
-Progress display
-
-Publish uses the same Rich tree renderer as dbp init, showing sync steps and publish progress (including streaming Arrow row counts and ETA for large datasets) as child nodes under the model.
+Behavior
+ • Iterates over every model registered in `dbport.lock`
+ • Executes models in parallel with a thread pool while preserving one Rich tree branch per model
+ • `load` reuses configured inputs for each model; `--update` refreshes each input to the newest available snapshot
+ • For `exec` and `run`, `--target` overrides each model's configured hook for that invocation
+ • For `publish` and `run`, `--dry-run` and `--refresh` map directly to DBPort publish modes
+ • Fails the overall command if any model fails, while still reporting which models completed successfully
 
 Example usage
 
-dbp publish --version 2026-03-15
-dbp publish test.table1 --version 2026-03-15
-dbp publish --refresh                             # overwrite latest version of default model
-dbp publish test.table1 --refresh                 # overwrite latest version of specific model
-dbp publish --version 2026-03-15 --dry-run
-dbp publish --version 2026-03-15 --message "Quarterly recompute"
+dbp project sync
+dbp project load
+dbp project load --update
+dbp project exec --target sql/transform.sql
+dbp project publish --dry-run
+dbp project publish --message "Quarterly recompute"
+dbp project run --refresh
 
 ⸻
 
@@ -522,23 +514,27 @@ Repo-level control plane for inspecting and managing project configuration.
 
 The config command is a subcommand group. It replaces the earlier dbp lock concept by unifying configuration management and lock file inspection into a single surface.
 
-Design: dbp status is the dashboard (quick operational summary across all models). dbp config is the control plane (deep inspection and configuration of persisted state for the resolved model).
+Design: dbp status is the dashboard for both operational summary and health inspection. dbp config is the control plane for managing persisted configuration.
 
-dbp config default
+The config group has two first-level subcommands:
+ • default
+ • model
+
+dbp config default model
 
 Show or set the default model for the project.
 
 Interface
 
-dbp config default [MODEL_KEY]
+dbp config default model [MODEL_KEY]
 
 Arguments
 
 MODEL_KEY         Model key (agency.dataset_id) to set as default
 
 Behavior
-	•	without argument: show current default model
-	•	with argument: validate the model exists in the lock, then set it as default
+ • without argument: show current default model
+ • with argument: validate the model exists in the lock, then set it as default
 
 The default model is persisted as a top-level default_model key in dbport.lock:
 
@@ -551,41 +547,32 @@ The default is set automatically on every dbp init. It can be changed deliberate
 
 Example usage
 
-dbp config default
-dbp config default wifor.emp__regional_trends
-dbp config default --json
+dbp config default model
+dbp config default model wifor.emp__regional_trends
+dbp config default model --json
 
-dbp config info
+dbp config model
 
-Inspect persisted lock file state for the resolved model.
-
-This is the deep dive into persisted state — input snapshots, version history, raw TOML.
+Manage configuration for a specific model.
 
 Interface
 
-dbp config info
-
-Flags
-
---inputs          Show detailed input table
---history         Show detailed version history table
---raw             Dump raw lock file TOML to stdout
+dbp config model MODEL_KEY version [VERSION]
+dbp config model MODEL_KEY columns
+dbp config model MODEL_KEY columns set COLUMN [--id ID] [--type TYPE] [--kind KIND] [--labels JSON]
+dbp config model MODEL_KEY columns attach COLUMN TABLE
 
 Behavior
-	•	default (no flags): summary for the resolved model — default model, identity, schema state, input count, version count
-	•	--inputs: detailed input table with table address, rows loaded, snapshot ID, snapshot timestamp, and filters
-	•	--history: detailed version history table with version, published_at, snapshot ID, rows, and completion status
-	•	--raw: raw TOML dump of the entire lock file (useful for debugging and piping)
-	•	flags can be combined: --inputs --history shows both tables
+ • version: show or set the configured publish version for the selected model
+ • columns: show current column metadata for the selected model
+ • columns set: update codelist metadata for a specific column
+ • columns attach: attach a DuckDB table as the codelist source for a column
 
 Example usage
 
-dbp config info
-dbp config info --inputs
-dbp config info --history
-dbp config info --raw
-dbp config info --inputs --history
-dbp config info --json
+dbp config model wifor.emp__regional_trends version 2026-03-16
+dbp config model wifor.emp__regional_trends columns set geo --id GEO --kind reference
+dbp config model wifor.emp__regional_trends columns attach geo wifor.cl_nuts2024
 
 ⸻
 
@@ -598,11 +585,11 @@ Purpose
 Separate validation from publishing so users can explicitly inspect readiness.
 
 Checks
-	•	output exists
-	•	schema contract is valid
-	•	required metadata is present
-	•	loaded inputs satisfy requirements
-	•	publish target is resolvable
+ • output exists
+ • schema contract is valid
+ • required metadata is present
+ • loaded inputs satisfy requirements
+ • publish target is resolvable
 
 Interface
 
@@ -632,28 +619,29 @@ Why it exists
 A production recompute is more than run + publish.
 
 It should:
-	•	resolve current inputs
-	•	compare input versions/snapshots with lock state
-	•	detect whether anything changed
-	•	skip unnecessary work when nothing changed
-	•	rerun and publish when changes exist
-	•	support forcing a rerun when needed
+ • resolve current inputs
+ • compare input versions/snapshots with lock state
+ • detect whether anything changed
+ • skip unnecessary work when nothing changed
+ • rerun and publish when changes exist
+ • support forcing a rerun when needed
 
 Default behavior
 
 Without flags, dbp recompute should:
-	1.	resolve configured inputs
-	2.	compare current input state to dbport.lock
-	3.	if no inputs changed:
-	•	skip rerun
-	•	skip publish
-	•	update recompute check state only
-	4.	if any inputs changed:
-	•	load changed inputs
-	•	run model
-	•	validate
-	•	publish
-	•	persist recompute outcome
+
+ 1. resolve configured inputs
+ 2. compare current input state to dbport.lock
+ 3. if no inputs changed:
+ • skip rerun
+ • skip publish
+ • update recompute check state only
+ 4. if any inputs changed:
+ • load changed inputs
+ • run model
+ • validate
+ • publish
+ • persist recompute outcome
 
 Interface
 
@@ -670,13 +658,13 @@ Flags
 --strict
 
 Flag meaning
-	•	--check — decide whether recompute is needed, but do not run it
-	•	--force — rerun even if no input changes are detected
-	•	--refresh — overwrite/rebuild publish target if allowed
-	•	--version TEXT — version to publish if recompute proceeds
-	•	--message TEXT — optional note for history/logging
-	•	--yes — skip prompts
-	•	--strict — fail on warnings or ambiguous state
+ • --check — decide whether recompute is needed, but do not run it
+ • --force — rerun even if no input changes are detected
+ • --refresh — overwrite/rebuild publish target if allowed
+ • --version TEXT — version to publish if recompute proceeds
+ • --message TEXT — optional note for history/logging
+ • --yes — skip prompts
+ • --strict — fail on warnings or ambiguous state
 
 Example usage
 
@@ -694,9 +682,9 @@ This is one of the most important parts of the CLI story.
 DBPort is explicitly intended for datasets that are rerun periodically in production.
 
 That means recompute must not be treated as:
-	•	an external scripting convention
-	•	an orchestration detail only
-	•	a manual combination of load, run, and publish
+ • an external scripting convention
+ • an orchestration detail only
+ • a manual combination of load, run, and publish
 
 It should be a built-in package concept.
 
@@ -709,12 +697,12 @@ A recompute is a decisioned workflow.
 The package should compute a plan before work starts.
 
 That plan should answer:
-	•	which inputs are configured
-	•	which versions/snapshots they currently resolve to
-	•	which changed since last successful recompute
-	•	whether rerun is required
-	•	whether publish is required
-	•	why the decision was made
+ • which inputs are configured
+ • which versions/snapshots they currently resolve to
+ • which changed since last successful recompute
+ • whether rerun is required
+ • whether publish is required
+ • why the decision was made
 
 Recommended internal concept
 
@@ -723,29 +711,29 @@ A RecomputePlan object in the runtime layer.
 Lock file should track recompute state
 
 The lock file should persist:
-	•	last checked time
-	•	last recomputed time
-	•	last successful publish version
-	•	last decision
-	•	last reason
-	•	per-input last seen vs last loaded versions/snapshots
+ • last checked time
+ • last recomputed time
+ • last successful publish version
+ • last decision
+ • last reason
+ • per-input last seen vs last loaded versions/snapshots
 
 This makes recompute visible and inspectable.
 
 Skip semantics
 
 If no relevant input changed:
-	•	no rerun
-	•	no publish
-	•	update recompute check state only
+ • no rerun
+ • no publish
+ • update recompute check state only
 
 Force semantics
 
 A recompute should still be possible with --force for:
-	•	code changes
-	•	schema changes
-	•	metadata changes
-	•	operational refreshes
+ • code changes
+ • schema changes
+ • metadata changes
+ • operational refreshes
 
 ⸻
 
@@ -762,11 +750,11 @@ Dev dependencies:
 uv add --dev pytest ruff mypy
 
 Why Typer + Rich
-	•	Typer gives a clean, modern command model with type hints
-	•	Rich gives readable interactive output, tables, panels, and status display
-	•	together they support both:
-	•	human-friendly local usage
-	•	scriptable machine output via --json
+ • Typer gives a clean, modern command model with type hints
+ • Rich gives readable interactive output, tables, panels, and status display
+ • together they support both:
+ • human-friendly local usage
+ • scriptable machine output via --json
 
 ⸻
 
@@ -790,13 +778,15 @@ src/
         __init__.py
         init.py            dbp init
         status.py          dbp status
-        check.py           dbp check
-        schema.py          dbp schema
-        load.py            dbp load
-        run.py             dbp run
-        execute.py         dbp execute
-        publish.py         dbp publish
-        config.py          dbp config (default, info)
+  check.py           dbp status check
+  schema.py          dbp config model <model> schema
+  model.py           dbp model sync|exec|publish|run
+  project.py         dbp project sync|exec|publish|run
+  run.py             hook execution helpers used by model/project commands
+  execute.py         legacy root exec command module
+  publish.py         legacy root publish command module
+  load.py            legacy root load command module
+  config.py          dbp config (default, model)
         validate.py        dbp validate (planned)
         recompute.py       dbp recompute (planned)
 
@@ -829,8 +819,10 @@ tests/
       test_status.py
       test_check.py
       test_schema.py
+   test_project.py
       test_load.py
       test_run.py
+   test_execute.py
       test_publish.py
       test_config.py
       test_context.py
@@ -842,14 +834,14 @@ File responsibilities
 
 pyproject.toml
 
-	•	package metadata and dependency declarations
-	•	console script registration: dbp = "dbport.cli:main"
+ • package metadata and dependency declarations
+ • console script registration: dbp = "dbport.cli:main"
 
 dbport.lock
 
 Primary persisted operational state (TOML, committable, no secrets):
-	•	default_model — active default for model resolution
-	•	per-model identity, schema, inputs, and versions under [models."agency.dataset_id"]
+ • default_model — active default for model resolution
+ • per-model identity, schema, inputs, and versions under [models."agency.dataset_id"]
 
 src/dbport/cli/main.py
 
@@ -858,11 +850,11 @@ Root Typer app. Registers all commands and the config sub-app. Handles global op
 src/dbport/cli/context.py
 
 Resolved CLI runtime context:
-	•	CliContext dataclass (project_path, lockfile_path, model_dir, output modes)
-	•	Model resolution logic (positional MODEL arg > --model flag > CWD match > default_model > first model)
-	•	Lock file read/write helpers (read_lock_models, read_default_model, write_default_model, read_lock_versions)
-	•	Model-key-based resolution: resolve_model_key(ctx, model_arg) returns (key, data) tuple
-	•	Path resolution from model data: resolve_model_paths_from_data(ctx, model_data) returns ModelPaths
+ • CliContext dataclass (project_path, lockfile_path, model_dir, output modes)
+ • Model resolution logic (positional MODEL arg > --model flag > CWD match > default_model > first model)
+ • Lock file read/write helpers (read_lock_models, read_default_model, write_default_model, read_lock_versions)
+ • Model-key-based resolution: resolve_model_key(ctx, model_arg) returns (key, data) tuple
+ • Path resolution from model data: resolve_model_paths_from_data(ctx, model_data) returns ModelPaths
 
 src/dbport/cli/options.py
 
@@ -871,12 +863,12 @@ Shared Typer Option definitions reused across commands.
 src/dbport/cli/render.py
 
 Rich output helpers:
-	•	Tables, panels, summaries, and JSON serialization helpers
-	•	Module-level console respects --no-color
-	•	`RichProgressAdapter` — flat spinner/progress bar for single-task progress (used by `dbp execute`, scaffold operations)
-	•	`ModelNode` — per-model tree progress callback with animated spinners for indeterminate tasks and text-based progress bars (row counts, ETA) for determinate tasks like streaming Arrow publish
-	•	`cli_progress()` — context manager wiring Rich progress to the `progress_callback` contextvar (flat display)
-	•	`cli_tree_progress()` — context manager rendering a Rich tree with per-model branches; yields a `model_context` factory for thread-safe per-model progress. Used by `dbp init`, `dbp run`, and `dbp publish`
+ • Tables, panels, summaries, and JSON serialization helpers
+ • Module-level console respects --no-color
+ • `RichProgressAdapter` — flat spinner/progress bar for single-task progress (used by `dbp model exec`, `dbp project exec`, and scaffold operations)
+ • `ModelNode` — per-model tree progress callback with animated spinners for indeterminate tasks and text-based progress bars (row counts, ETA) for determinate tasks like streaming Arrow publish
+ • `cli_progress()` — context manager wiring Rich progress to the `progress_callback` contextvar (flat display)
+ • `cli_tree_progress()` — context manager rendering a Rich tree with per-model branches; yields a `model_context` factory for thread-safe per-model progress. Used by `dbp model sync|publish|run` and all `dbp project ...` lifecycle commands
 
 src/dbport/cli/errors.py
 
@@ -898,28 +890,28 @@ Output model
 Human output
 
 Default output uses Rich for:
-	•	tables
-	•	panels
-	•	status summaries
-	•	warnings
-	•	success/failure states
+ • tables
+ • panels
+ • status summaries
+ • warnings
+ • success/failure states
 
 Progress display
 
 Commands that perform long-running operations show real-time progress using Rich.
 
-Single-task commands (load, execute) use a flat spinner/progress bar:
-	•	Indeterminate tasks show an animated spinner with a description
-	•	Determinate tasks (e.g. streaming Arrow publish) show a progress bar with row counts, elapsed time, and ETA
+Single-task commands (`dbp model exec`, `dbp project exec`) use a flat spinner/progress bar:
+ • Indeterminate tasks show an animated spinner with a description
+ • Determinate tasks (e.g. streaming Arrow publish) show a progress bar with row counts, elapsed time, and ETA
 
-Model-level commands (init, run, publish) use a Rich tree layout:
-	•	Each model is a parent node with an animated spinner while in progress, then ✓ or ✗ when done
-	•	Steps (sync, execute, publish) appear as child nodes under each model
-	•	Indeterminate steps show animated spinners with live elapsed time (e.g. schema detection, loading, executing)
-	•	Determinate steps show text-based progress bars: `━━━━━━━━━━ 500,000 / 1,485,615 rows  ETA 0:02:45`
-	•	For `dbp init` with multiple models, models run in parallel; the tree updates thread-safely from concurrent workers
+Model and project lifecycle commands use a Rich tree layout:
+ • Each model is a parent node with an animated spinner while in progress, then ✓ or ✗ when done
+ • Steps (sync, execute, publish) appear as child nodes under each model
+ • Indeterminate steps show animated spinners with live elapsed time (e.g. schema detection, loading, executing)
+ • Determinate steps show text-based progress bars: `━━━━━━━━━━ 500,000 / 1,485,615 rows  ETA 0:02:45`
+ • For `dbp project ...`, models run in parallel and the tree updates each model branch independently without losing spinner or progress-bar detail
 
-All tree-based commands (`dbp init`, `dbp run`, `dbp publish`) use the same `cli_tree_progress` renderer for a consistent experience.
+All tree-based lifecycle commands use the same `cli_tree_progress` renderer for a consistent experience.
 
 Machine output
 
@@ -971,11 +963,11 @@ rows = 1485615
 completed = true
 
 Key properties:
-	•	single file per repo, at the repo root next to pyproject.toml
-	•	multi-model: each model namespaced under [models."agency.dataset_id"]
-	•	model_root and duckdb_path are relative to repo root
-	•	no secrets — safe to commit
-	•	managed automatically by CLI commands — not meant for hand-editing
+ • single file per repo, at the repo root next to pyproject.toml
+ • multi-model: each model namespaced under [models."agency.dataset_id"]
+ • model_root and duckdb_path are relative to repo root
+ • no secrets — safe to commit
+ • managed automatically by CLI commands — not meant for hand-editing
 
 ⸻
 
@@ -984,20 +976,19 @@ Example user workflow
 dbp init regional_trends --template hybrid --dataset emp__regional_trends --agency wifor
 cd regional_trends
 
-dbp check
+dbp status check
 dbp status
 
-dbp schema sql/create_output.sql
-dbp load
-dbp run --version 2026-03-15 --timing            # full lifecycle: sync, execute, publish
-dbp publish --refresh                             # re-publish latest version
+dbp config model wifor.emp__regional_trends schema sql/create_output.sql
+dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers
+dbp model run --version 2026-03-15 --timing      # full lifecycle: sync, execute, publish
+dbp model publish --refresh                       # re-publish latest version
 
-dbp run wifor.emp__regional_trends --timing       # address specific model
-dbp publish wifor.emp__regional_trends --refresh  # re-publish specific model
+dbp model run wifor.emp__regional_trends --timing      # address specific model
+dbp model publish wifor.emp__regional_trends --refresh  # re-publish specific model
 
-dbp config info --inputs
-dbp config info --history
-dbp config default
+dbp status --show-history
+dbp config default model
 
 ⸻
 

--- a/examples/minimal/main.py
+++ b/examples/minimal/main.py
@@ -1,13 +1,14 @@
-"""Minimal DBPort example — demonstrates the full Python client API.
+"""Minimal DBPort example and CLI-safe model hook for table1.
 
-Loads inputs from the warehouse (with filters), configures column metadata
-and codelist attachments, runs multi-step transforms, and publishes with
-all three modes (dry-run, normal, refresh).
+When executed through the CLI, DBPort injects an active ``port`` and calls
+``run(port)``. When executed directly as a Python script, this file opens its
+own DBPort instance.
 """
 
 from dbport import DBPort
 
-with DBPort(agency="test", dataset_id="table1") as port:
+
+def run(port: DBPort) -> None:
     # 1. Ensure target schema exists in DuckDB
     port.execute("CREATE SCHEMA IF NOT EXISTS test")
 
@@ -29,11 +30,11 @@ with DBPort(agency="test", dataset_id="table1") as port:
     port.execute("sql/staging.sql")
     port.execute("sql/transform.sql")
 
-    # 7. Dry-run publish — validates schema only, no data written
-    port.publish(version="2026-03-16", params={"wstatus": "EMP"}, mode="dry")
 
-    # 8. Normal publish — idempotent, skips if version already completed
-    port.publish(version="2026-03-16", params={"wstatus": "EMP"})
-
-    # 9. Refresh publish — overwrites existing version unconditionally
-    port.publish(version="2026-03-16", params={"wstatus": "EMP"}, mode="refresh")
+if __name__ == "__main__":
+    with DBPort(agency="test", dataset_id="table1") as port:
+        run(port)
+        # Standalone client usage can still own publish explicitly.
+        port.publish(version="2026-03-16", params={"wstatus": "EMP"}, mode="dry")
+        port.publish(version="2026-03-16", params={"wstatus": "EMP"})
+        port.publish(version="2026-03-16", params={"wstatus": "EMP"}, mode="refresh")

--- a/examples/minimal_cli/run.sh
+++ b/examples/minimal_cli/run.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Minimal CLI example — demonstrates the full `dbp` command surface.
 #
-# Covers: init, config (default, run-hook, meta, attach, info),
-# check, schema, load, execute, publish (dry/normal/refresh),
-# run (hook-based), and status.
+# Covers: init, config (default, schema, input, meta, attach),
+# status check, model exec/publish/run, project sync, and status.
 #
 # Uses CWD-based model resolution — no --model flag needed.
 #
@@ -24,57 +23,62 @@ dbp init minimal_cli --agency test --dataset cli_table1 --path examples/minimal_
 
 echo ""
 echo "=== 2. Config: set defaults ==="
-dbp config default test.cli_table1
-dbp config run-hook sql/main.sql
-dbp config version "$VERSION"
-dbp config info
+dbp config default model test.cli_table1
+dbp config default hook main.py
+dbp config model test.cli_table1 version "$VERSION"
+dbp status
+
+echo ""
+echo "=== 2b. Project-wide sync ==="
+dbp project sync
 
 echo ""
 echo "=== 3. Check project health ==="
-dbp check
+dbp status check
 
 # cd into model directory — all subsequent commands resolve model from CWD
 cd examples/minimal_cli
 
 echo ""
 echo "=== 4. Apply the output schema ==="
-dbp schema sql/create_output.sql
+dbp config model test.cli_table1 schema sql/create_output.sql
 
 echo ""
 echo "=== 5. Column metadata ==="
-dbp config meta geo --id GEO --kind reference
-dbp config meta year --type categorical
-dbp config meta                  # show all column metadata
+dbp config model test.cli_table1 columns set geo --id GEO --kind reference
+dbp config model test.cli_table1 columns set year --type categorical
+dbp config model test.cli_table1 columns               # show all column metadata
 
 echo ""
 echo "=== 6. Load inputs ==="
-dbp load estat.nama_10r_3empers
-dbp load wifor.cl_nuts2024
+dbp config model test.cli_table1 input estat.nama_10r_3empers
+dbp config model test.cli_table1 input wifor.cl_nuts2024
+dbp model load test.cli_table1
 
 echo ""
 echo "=== 7. Attach codelist table to column ==="
-dbp config attach geo --table wifor.cl_nuts2024
+dbp config model test.cli_table1 columns attach geo wifor.cl_nuts2024
 
 echo ""
 echo "=== 8. Execute multi-step transforms ==="
-dbp execute sql/staging.sql --timing
-dbp execute sql/transform.sql --timing
+dbp model exec test.cli_table1 --target sql/staging.sql --timing
+dbp model exec test.cli_table1 --target sql/transform.sql --timing
 
 echo ""
 echo "=== 9. Publish: dry-run ==="
-dbp publish --version "$VERSION" --dry-run --yes
+dbp model publish test.cli_table1 --version "$VERSION" --dry-run
 
 echo ""
 echo "=== 10. Publish: normal ==="
-dbp publish --version "$VERSION" --yes
+dbp model publish test.cli_table1 --version "$VERSION"
 
 echo ""
 echo "=== 11. Publish: refresh (overwrite) ==="
-dbp publish --version "$VERSION" --refresh --yes
+dbp model publish test.cli_table1 --version "$VERSION" --refresh
 
 echo ""
 echo "=== 12. Run (hook-based workflow, auto-publishes with configured version) ==="
-dbp run --timing --refresh
+dbp model run test.cli_table1 --timing --refresh
 
 echo ""
 echo "=== 13. Status ==="

--- a/src/dbport/adapters/primary/client.py
+++ b/src/dbport/adapters/primary/client.py
@@ -54,6 +54,7 @@ def _caller_dir(stack_depth: int = 2) -> Path:
     stack_depth=2: frame 0 = _caller_dir, frame 1 = __init__, frame 2 = user code.
     """
     import inspect
+
     frame = inspect.stack()[stack_depth]
     return Path(frame.filename).resolve().parent
 
@@ -85,6 +86,7 @@ class DBPort:
         duckdb_path: str | None = None,
         lock_path: str | None = None,
         model_root: str | None = None,
+        load_inputs_on_init: bool = True,
     ) -> None:
         setup_logging()
 
@@ -172,14 +174,21 @@ class DBPort:
         # Public column registry
         self.columns = ColumnRegistry(self._lock)
 
-        # Auto-detect schema from warehouse if table exists
-        self._auto_detect_schema()
+        from ...infrastructure.progress import progress_phase
 
-        # Sync local DuckDB state with lock + warehouse
-        self._sync_local_state()
+        with progress_phase("sync", title="Sync", icon="🔄"):
+            # Auto-detect schema from warehouse if table exists
+            self._auto_detect_schema()
 
-        # Update last_fetched_at on every run (fire-and-forget)
-        self._update_last_fetched()
+            # Sync local DuckDB output state with lock + warehouse
+            self._sync_output_state()
+
+            # Update last_fetched_at on every run (fire-and-forget)
+            self._update_last_fetched()
+
+        if load_inputs_on_init:
+            with progress_phase("load", title="Load", icon="📥"):
+                self._load_inputs()
 
         logger.debug(
             "Ready: %s (model_root=%s, duckdb=%s)",
@@ -196,7 +205,10 @@ class DBPort:
         """Declare the output table schema from a DDL string or .sql file path."""
         from ...application.services.schema import DefineSchemaService
 
-        svc = DefineSchemaService(self._compute, self._lock)
+        svc = DefineSchemaService(self._compute, self._lock).with_catalog(
+            self._catalog,
+            self._dataset.table_address,
+        )
         svc.execute(ddl_or_path, base_dir=self._dataset.model_root)
         self.columns._refresh()
 
@@ -206,7 +218,7 @@ class DBPort:
         *,
         filters: dict[str, str] | None = None,
         version: str | None = None,
-    ) -> None:
+    ) -> IngestRecord:
         """Load an Iceberg table into DuckDB.
 
         For tables published by DBPort, the load is automatically
@@ -229,7 +241,23 @@ class DBPort:
         declaration = InputDeclaration(
             table_address=table_address, filters=filters, version=version
         )
-        svc.execute(declaration)
+        return svc.execute(declaration)
+
+    def configure_input(
+        self,
+        table_address: str,
+        *,
+        filters: dict[str, str] | None = None,
+        version: str | None = None,
+    ) -> IngestRecord:
+        """Validate and persist an input declaration without loading it."""
+        from ...application.services.ingest import IngestService
+
+        svc = IngestService(self._catalog, self._compute, self._lock)
+        declaration = InputDeclaration(
+            table_address=table_address, filters=filters, version=version
+        )
+        return svc.configure(declaration)
 
     def execute(self, sql_or_path: str) -> None:
         """Run a SQL string or .sql file in DuckDB."""
@@ -257,8 +285,10 @@ class DBPort:
 
     @property
     def run_hook(self) -> str | None:
-        """Return the configured run hook path, or None if not set."""
-        return self._lock.read_run_hook()
+        """Return the configured run hook path, defaulting to main.py."""
+        from ...application.services.run import resolve_run_hook
+
+        return resolve_run_hook(self._lock)
 
     def publish(
         self,
@@ -313,18 +343,24 @@ class DBPort:
         duckdb_path: str,
     ) -> ILockStore:
         from ...adapters.secondary.lock.toml import TomlLockAdapter
-        return TomlLockAdapter(path, model_key=model_key, model_root=model_root, duckdb_path=duckdb_path)
+
+        return TomlLockAdapter(
+            path, model_key=model_key, model_root=model_root, duckdb_path=duckdb_path
+        )
 
     def _make_compute(self, path: Path) -> ICompute:
         from ...adapters.secondary.compute.duckdb import DuckDBComputeAdapter
+
         return DuckDBComputeAdapter(path)
 
     def _make_catalog(self, creds: WarehouseCreds) -> ICatalog:
         from ...adapters.secondary.catalog.iceberg import IcebergCatalogAdapter
+
         return IcebergCatalogAdapter(creds)
 
     def _make_metadata(self) -> IMetadataStore:
         from ...adapters.secondary.metadata.materialize import MetadataAdapter
+
         return MetadataAdapter()
 
     def _auto_detect_schema(self) -> None:
@@ -355,15 +391,25 @@ class DBPort:
                 cb.finished("Schema detection skipped")
             logger.debug("Auto-schema detection skipped: %s", exc)
 
-    def _sync_local_state(self) -> None:
-        """Sync DuckDB with lock file: output table + inputs."""
+    def _sync_output_state(self) -> None:
+        """Sync DuckDB output table with lock file state."""
         from ...application.services.sync import SyncService
 
         try:
             svc = SyncService(self._catalog, self._compute, self._lock)
-            svc.execute(self._dataset.table_address)
+            svc.sync_output_table(self._dataset.table_address)
         except Exception as exc:
             logger.debug("Local sync skipped: %s", exc)
+
+    def _load_inputs(self) -> None:
+        """Load configured inputs into DuckDB."""
+        from ...application.services.sync import SyncService
+
+        try:
+            svc = SyncService(self._catalog, self._compute, self._lock)
+            svc.sync_inputs()
+        except Exception as exc:
+            logger.debug("Input sync skipped: %s", exc)
 
     def _update_last_fetched(self) -> None:
         from ...application.services.fetch import FetchService

--- a/src/dbport/adapters/secondary/catalog/iceberg.py
+++ b/src/dbport/adapters/secondary/catalog/iceberg.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -157,8 +158,6 @@ class IcebergCatalogAdapter:
             if creds.s3_secret_key:
                 compute.execute(f"SET s3_secret_access_key='{_sql_escape(creds.s3_secret_key)}'")
 
-
-
         # REST catalog secret
         compute.execute(
             "CREATE OR REPLACE SECRET dbport_iceberg_catalog ("
@@ -261,6 +260,126 @@ class IcebergCatalogAdapter:
                 f"{[e.get('version') for e in versions_list]}"
             )
 
+    @staticmethod
+    def _build_row_filter(filters: dict[str, str] | None) -> Any:
+        if not filters:
+            return None
+
+        try:
+            from pyiceberg.expressions import And, EqualTo
+        except ImportError as exc:
+            raise RuntimeError(
+                "pyiceberg is required for input inspection. "
+                "Install it: pip install 'pyiceberg[s3fs]'"
+            ) from exc
+
+        expr: Any = None
+        for col, val in filters.items():
+            term = EqualTo(str(col), value=val)
+            expr = term if expr is None else And(expr, term)
+        return expr
+
+    @staticmethod
+    def _snapshot_timestamp_from_table(
+        iceberg_table: Any,
+        snapshot_id: int | None,
+    ) -> int | None:
+        if snapshot_id is None:
+            return None
+
+        snapshot: Any | None = None
+        try:
+            snapshot_by_id = getattr(iceberg_table, "snapshot_by_id", None)
+            if callable(snapshot_by_id):
+                snapshot = snapshot_by_id(snapshot_id)
+        except Exception:
+            snapshot = None
+
+        if snapshot is None:
+            try:
+                current_snapshot = getattr(iceberg_table, "current_snapshot", None)
+                if callable(current_snapshot):
+                    current = current_snapshot()
+                    if getattr(current, "snapshot_id", None) == snapshot_id:
+                        snapshot = current
+            except Exception:
+                snapshot = None
+
+        if snapshot is None:
+            return None
+
+        value = getattr(snapshot, "timestamp_ms", None)
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _inspect_input_row_count(
+        self,
+        iceberg_table: Any,
+        declaration: InputDeclaration,
+        *,
+        snapshot_id: int | None,
+    ) -> int:
+        estimated_total = self._estimate_ingest_total_rows(
+            iceberg_table,
+            snapshot_id=snapshot_id,
+            has_filter=bool(declaration.filters),
+        )
+        if estimated_total is not None:
+            return int(estimated_total)
+
+        row_filter = self._build_row_filter(declaration.filters)
+        scan_kwargs: dict[str, Any] = {}
+        if snapshot_id is not None:
+            scan_kwargs["snapshot_id"] = snapshot_id
+        if row_filter is not None:
+            scan_kwargs["row_filter"] = row_filter
+
+        scan = iceberg_table.scan(**scan_kwargs)
+        reader = scan.to_arrow_batch_reader()
+        return sum(batch.num_rows for batch in reader)
+
+    def inspect_input(
+        self,
+        declaration: InputDeclaration,
+    ) -> IngestRecord:
+        from ....domain.entities.input import IngestRecord
+
+        catalog = self._get_catalog()
+        ns, name = self._parse_address(declaration.table_address)
+        iceberg_table = catalog.load_table((ns, name))
+
+        resolved_version, resolved_snap_id = self.resolve_input_snapshot(
+            declaration.table_address,
+            declaration.version,
+        )
+
+        if declaration.version is not None and resolved_version is None:
+            raise ValueError(
+                f"Version {declaration.version!r} cannot be resolved for "
+                f"{declaration.table_address!r} because the table has no dbport metadata."
+            )
+
+        snap_ts_ms = self._snapshot_timestamp_from_table(iceberg_table, resolved_snap_id)
+        if resolved_snap_id is None:
+            resolved_snap_id, snap_ts_ms = self.current_snapshot(declaration.table_address)
+
+        rows_loaded = self._inspect_input_row_count(
+            iceberg_table,
+            declaration,
+            snapshot_id=resolved_snap_id,
+        )
+
+        return IngestRecord(
+            table_address=declaration.table_address,
+            last_snapshot_id=resolved_snap_id,
+            last_snapshot_timestamp_ms=snap_ts_ms,
+            rows_loaded=rows_loaded,
+            filters=declaration.filters,
+            version=resolved_version,
+        )
+
     _MAX_INGEST_RETRIES = 3
     _INGEST_RETRY_BACKOFF = (2, 4, 8)  # seconds
 
@@ -270,16 +389,23 @@ class IcebergCatalogAdapter:
         msg = str(exc).lower()
         # S3 key/auth errors that may be transient (token refresh, eventual consistency)
         for pattern in (
-            "invalidkey", "invalid key",
-            "nosuchkey", "no such key",
+            "invalidkey",
+            "invalid key",
+            "nosuchkey",
+            "no such key",
             "invalidaccesskeyid",
-            "requesttimeout", "request timeout",
+            "requesttimeout",
+            "request timeout",
             "slowdown",
-            "serviceunavailable", "service unavailable",
-            "internalerror", "internal error",
-            "connection reset", "connection aborted",
+            "serviceunavailable",
+            "service unavailable",
+            "internalerror",
+            "internal error",
+            "connection reset",
+            "connection aborted",
             "broken pipe",
-            "ioerror", "oserror",
+            "ioerror",
+            "oserror",
         ):
             if pattern in msg:
                 return True
@@ -308,13 +434,7 @@ class IcebergCatalogAdapter:
         """
         import time
 
-        try:
-            from pyiceberg.expressions import And, EqualTo
-        except ImportError as exc:
-            raise RuntimeError(
-                "pyiceberg is required for Arrow ingest fallback. "
-                "Install it: pip install 'pyiceberg[s3fs]'"
-            ) from exc
+        import pyarrow as pa
 
         from ....infrastructure.progress import progress_callback
 
@@ -322,13 +442,7 @@ class IcebergCatalogAdapter:
         ns, name = self._parse_address(declaration.table_address)
 
         # Build pyiceberg row filter from filters dict
-        row_filter: Any = None
-        if declaration.filters:
-            expr: Any = None
-            for col, val in declaration.filters.items():
-                term = EqualTo(str(col), value=val)
-                expr = term if expr is None else And(expr, term)
-            row_filter = expr
+        row_filter: Any = self._build_row_filter(declaration.filters)
 
         # Build scan kwargs — pin to snapshot when known (Fix A)
         scan_kwargs: dict[str, Any] = {}
@@ -345,31 +459,43 @@ class IcebergCatalogAdapter:
             try:
                 iceberg_table = catalog.load_table((ns, name))
                 scan = iceberg_table.scan(**scan_kwargs)
+                estimated_total = self._estimate_ingest_total_rows(
+                    iceberg_table,
+                    snapshot_id=snapshot_id,
+                    has_filter=(row_filter is not None),
+                )
 
                 if cb:
-                    cb.started(f"Loading {declaration.table_address}", total=None)
+                    cb.started(
+                        f"Loading {declaration.table_address}",
+                        total=estimated_total,
+                    )
 
                 reader = scan.to_arrow_batch_reader()
+                counted_reader = pa.RecordBatchReader.from_batches(
+                    reader.schema,
+                    self._iter_batches_with_progress(reader, cb),
+                )
                 compute.execute(f"CREATE SCHEMA IF NOT EXISTS {ns}")
-                compute.register_arrow("_dbport_ingest_tmp", reader)
+                compute.register_arrow("_dbport_ingest_tmp", counted_reader)
                 try:
                     compute.execute(
-                        f"CREATE OR REPLACE TABLE {ns}.{name} AS "
-                        f"SELECT * FROM _dbport_ingest_tmp"
+                        f"CREATE OR REPLACE TABLE {ns}.{name} AS SELECT * FROM _dbport_ingest_tmp"
                     )
                 finally:
                     compute.unregister_arrow("_dbport_ingest_tmp")
 
-                row_count = compute.execute(
-                    f"SELECT COUNT(*) FROM {ns}.{name}"
-                ).fetchone()[0]
+                row_count = compute.execute(f"SELECT COUNT(*) FROM {ns}.{name}").fetchone()[0]
 
                 if cb:
                     cb.finished(f"Loaded {declaration.table_address} ({row_count:,} rows)")
 
                 logger.debug(
                     "Arrow ingest: %d rows into %s.%s (snapshot=%s)",
-                    row_count, ns, name, snapshot_id,
+                    row_count,
+                    ns,
+                    name,
+                    snapshot_id,
                 )
                 return int(row_count)
 
@@ -391,14 +517,96 @@ class IcebergCatalogAdapter:
                 elif cb:
                     cb.finished()
                 logger.warning(
-                    "Transient error loading %s (attempt %d/%d): %s; "
-                    "retrying in %ds",
-                    declaration.table_address, attempt,
-                    self._MAX_INGEST_RETRIES, exc, backoff,
+                    "Transient error loading %s (attempt %d/%d): %s; retrying in %ds",
+                    declaration.table_address,
+                    attempt,
+                    self._MAX_INGEST_RETRIES,
+                    exc,
+                    backoff,
                 )
                 time.sleep(backoff)
 
         raise last_exc  # type: ignore[misc]  # pragma: no cover — unreachable, satisfies type checker
+
+    @staticmethod
+    def _iter_batches_with_progress(reader: Any, cb: Any):
+        """Yield batches while advancing the active progress callback."""
+        for batch in reader:
+            if cb is not None:
+                cb.update(batch.num_rows)
+            yield batch
+
+    @staticmethod
+    def _snapshot_summary(snapshot: Any) -> dict[str, Any]:
+        """Return the best-effort summary dict for a pyiceberg snapshot object."""
+        summary = getattr(snapshot, "summary", None)
+        if callable(summary):
+            try:
+                summary = summary()
+            except Exception:
+                summary = None
+        if isinstance(summary, Mapping):
+            result: dict[str, Any] = {}
+            try:
+                for item in summary:
+                    if isinstance(item, tuple) and len(item) == 2:
+                        key, value = item
+                    else:
+                        key = item
+                        value = summary[key]
+                    if isinstance(key, str):
+                        result[key] = value
+            except Exception:
+                return {}
+            return result
+        return {}
+
+    def _estimate_ingest_total_rows(
+        self,
+        iceberg_table: Any,
+        *,
+        snapshot_id: int | None,
+        has_filter: bool,
+    ) -> int | None:
+        """Estimate row count for an ingest progress bar from snapshot metadata.
+
+        Returns ``None`` when a cheap estimate is not available, for example
+        when filters are applied or the snapshot summary does not expose a row
+        count field.
+        """
+        if has_filter:
+            return None
+
+        snapshot: Any | None = None
+        try:
+            if snapshot_id is not None:
+                snapshot_by_id = getattr(iceberg_table, "snapshot_by_id", None)
+                if callable(snapshot_by_id):
+                    snapshot = snapshot_by_id(snapshot_id)
+        except Exception:
+            snapshot = None
+
+        if snapshot is None:
+            try:
+                current_snapshot = getattr(iceberg_table, "current_snapshot", None)
+                if callable(current_snapshot):
+                    snapshot = current_snapshot()
+            except Exception:
+                snapshot = None
+
+        if snapshot is None:
+            return None
+
+        summary = self._snapshot_summary(snapshot)
+        for key in ("total-records", "added-records"):
+            value = summary.get(key)
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        return None
 
     def ingest_into_compute(
         self,
@@ -474,7 +682,10 @@ class IcebergCatalogAdapter:
     _CHECKPOINT_RETRIES = 3
 
     def _write_checkpoint_with_retry(
-        self, ns: str, name: str, properties: dict[str, str],
+        self,
+        ns: str,
+        name: str,
+        properties: dict[str, str],
     ) -> None:
         """Write completion checkpoint properties with retry on transient failures."""
         import time
@@ -487,20 +698,27 @@ class IcebergCatalogAdapter:
                 return
             except Exception as exc:
                 if attempt < self._CHECKPOINT_RETRIES:
-                    delay = 2 ** attempt
+                    delay = 2**attempt
                     logger.warning(
                         "Checkpoint write attempt %d/%d failed: %s (retrying in %ds)",
-                        attempt, self._CHECKPOINT_RETRIES, exc, delay,
+                        attempt,
+                        self._CHECKPOINT_RETRIES,
+                        exc,
+                        delay,
                     )
                     time.sleep(delay)
                 else:
                     logger.error(
                         "Checkpoint write failed after %d attempts: %s",
-                        self._CHECKPOINT_RETRIES, exc,
+                        self._CHECKPOINT_RETRIES,
+                        exc,
                     )
 
     def _write_via_duckdb(
-        self, table_address: str, compute: Any, overwrite: bool,
+        self,
+        table_address: str,
+        compute: Any,
+        overwrite: bool,
     ) -> None:
         """Primary write path: DuckDB iceberg extension. Data never leaves DuckDB."""
         self._ensure_warehouse_attached(compute)
@@ -521,14 +739,14 @@ class IcebergCatalogAdapter:
                     logger.error(
                         "CREATE failed after DROP for %s — table was dropped "
                         "but could not be recreated: %s",
-                        table_address, exc,
+                        table_address,
+                        exc,
                     )
                 raise
         else:
             try:
                 compute.execute(
-                    f"INSERT INTO dbport_warehouse.{table_address} "
-                    f"SELECT * FROM {table_address}"
+                    f"INSERT INTO dbport_warehouse.{table_address} SELECT * FROM {table_address}"
                 )
             except Exception as exc:
                 # Only fall through to CREATE if this looks like a missing-table error.
@@ -579,7 +797,8 @@ class IcebergCatalogAdapter:
 
         # Get Arrow schema from DuckDB (zero rows)
         schema_reader = compute.to_arrow_batches(
-            f"SELECT * FROM {table_address} LIMIT 0", batch_size=1,
+            f"SELECT * FROM {table_address} LIMIT 0",
+            batch_size=1,
         )
         arrow_schema = schema_reader.schema
 
@@ -598,7 +817,8 @@ class IcebergCatalogAdapter:
                 iceberg_table = catalog.load_table((ns, name))
             except Exception:
                 iceberg_table = catalog.create_table(
-                    f"{ns}.{name}", schema=arrow_schema,
+                    f"{ns}.{name}",
+                    schema=arrow_schema,
                 )
 
             # Read checkpoint from remote
@@ -641,10 +861,12 @@ class IcebergCatalogAdapter:
                     # Atomic: data append + checkpoint in one transaction
                     tx = iceberg_table.transaction()
                     tx.append(arrow_chunk)
-                    tx.set_properties({
-                        batches_prop: str(batches_total + 1),
-                        rows_prop: str(rows_total + batch.num_rows),
-                    })
+                    tx.set_properties(
+                        {
+                            batches_prop: str(batches_total + 1),
+                            rows_prop: str(rows_total + batch.num_rows),
+                        }
+                    )
                     tx.commit_transaction()
 
                     batches_total += 1
@@ -656,7 +878,8 @@ class IcebergCatalogAdapter:
                     if batches_total % 20 == 0:
                         logger.debug(
                             "Streaming write progress: %d/%d rows (%.0f%%)",
-                            rows_total, total_rows,
+                            rows_total,
+                            total_rows,
                             100 * rows_total / total_rows if total_rows else 0,
                         )
 
@@ -666,7 +889,8 @@ class IcebergCatalogAdapter:
                         had_conflict = True
                         logger.warning(
                             "Commit conflict (attempt %d/%d); retrying from checkpoint",
-                            attempt, self._MAX_COMMIT_CONFLICT_RETRIES,
+                            attempt,
+                            self._MAX_COMMIT_CONFLICT_RETRIES,
                         )
                         break
                     raise
@@ -682,17 +906,19 @@ class IcebergCatalogAdapter:
 
             # Mark completed
             self._write_checkpoint_with_retry(
-                ns, name, {completed_prop: "1", rows_prop: str(rows_total)},
+                ns,
+                name,
+                {completed_prop: "1", rows_prop: str(rows_total)},
             )
 
             if cb:
-                cb.finished(
-                    f"Published {table_address} ({rows_total:,} rows)"
-                )
+                cb.finished(f"Published {table_address} ({rows_total:,} rows)")
 
             logger.debug(
                 "Streaming write complete: %d rows in %d batches (%s)",
-                rows_total, batches_total, table_address,
+                rows_total,
+                batches_total,
+                table_address,
             )
             break  # Done
 
@@ -736,12 +962,15 @@ class IcebergCatalogAdapter:
                         cb.log(f"Version {version_key} already completed; skipping")
                     logger.info(
                         "Version %s already completed; skipping (table=%s rows=%d)",
-                        version_key, table_address, committed_rows,
+                        version_key,
+                        table_address,
+                        committed_rows,
                     )
                     snap_id, snap_ts_ms = self.current_snapshot(table_address)
                     snap_ts = (
                         datetime.fromtimestamp(snap_ts_ms / 1000, tz=UTC)
-                        if snap_ts_ms is not None else None
+                        if snap_ts_ms is not None
+                        else None
                     )
                     return VersionRecord(
                         version=version.version,
@@ -755,25 +984,26 @@ class IcebergCatalogAdapter:
             except Exception:
                 pass  # Table doesn't exist yet — proceed with write
 
-        row_count = compute.execute(
-            f"SELECT COUNT(*) FROM {table_address}"
-        ).fetchone()[0]
+        row_count = compute.execute(f"SELECT COUNT(*) FROM {table_address}").fetchone()[0]
 
         cb = progress_callback.get(None)
+
+        if overwrite:
+            logger.info(
+                "Using streaming Arrow fallback for refresh publish (table=%s)",
+                table_address,
+            )
+            self._duckdb_writes_supported = False
 
         # --- Primary: DuckDB iceberg extension ---
         if self._duckdb_writes_supported is not False:
             if cb:
-                cb.started(
-                    f"Publishing {table_address} ({row_count:,} rows)", total=None
-                )
+                cb.started(f"Publishing {table_address} ({row_count:,} rows)", total=None)
             try:
                 self._write_via_duckdb(table_address, compute, overwrite)
                 self._duckdb_writes_supported = True
                 if cb:
-                    cb.finished(
-                        f"Published {table_address} ({row_count:,} rows)"
-                    )
+                    cb.finished(f"Published {table_address} ({row_count:,} rows)")
             except Exception as exc:
                 if self._is_duckdb_write_unsupported(exc):
                     if cb:
@@ -796,19 +1026,27 @@ class IcebergCatalogAdapter:
         # --- Fallback: streaming Arrow via pyiceberg ---
         if self._duckdb_writes_supported is False:
             self._write_via_streaming_arrow(
-                table_address, version, compute, overwrite, row_count,
+                table_address,
+                version,
+                compute,
+                overwrite,
+                row_count,
             )
 
         logger.debug(
             "write_versioned: done (table=%s version=%s rows=%d)",
-            table_address, version_key, row_count,
+            table_address,
+            version_key,
+            row_count,
         )
 
         # Mark completed (DuckDB path only; fallback marks its own)
         if self._duckdb_writes_supported is True:
             ns, name = self._parse_address(table_address)
             self._write_checkpoint_with_retry(
-                ns, name, {completed_prop: "1", rows_prop: str(row_count)},
+                ns,
+                name,
+                {completed_prop: "1", rows_prop: str(row_count)},
             )
 
         snap_id, snap_ts_ms = self.current_snapshot(table_address)
@@ -826,9 +1064,7 @@ class IcebergCatalogAdapter:
             completed=True,
         )
 
-    def get_table_property(
-        self, table_address: str, key: str
-    ) -> str | None:
+    def get_table_property(self, table_address: str, key: str) -> str | None:
         """Return a single table property value, or None if not set."""
         catalog = self._get_catalog()
         ns, name = self._parse_address(table_address)
@@ -838,18 +1074,14 @@ class IcebergCatalogAdapter:
         except Exception:
             return None
 
-    def update_table_properties(
-        self, table_address: str, properties: dict[str, str]
-    ) -> None:
+    def update_table_properties(self, table_address: str, properties: dict[str, str]) -> None:
         """Merge key/value properties into the Iceberg table metadata."""
         catalog = self._get_catalog()
         ns, name = self._parse_address(table_address)
         table = catalog.load_table((ns, name))
         _write_table_properties(table, properties)
 
-    def update_column_docs(
-        self, table_address: str, column_docs: dict[str, str]
-    ) -> None:
+    def update_column_docs(self, table_address: str, column_docs: dict[str, str]) -> None:
         """Write column doc strings to the Iceberg table schema."""
         catalog = self._get_catalog()
         ns, name = self._parse_address(table_address)

--- a/src/dbport/application/services/ingest.py
+++ b/src/dbport/application/services/ingest.py
@@ -30,12 +30,21 @@ class IngestService:
       dbport.lock.
     """
 
-    def __init__(
-        self, catalog: ICatalog, compute: ICompute, lock: ILockStore
-    ) -> None:
+    def __init__(self, catalog: ICatalog, compute: ICompute, lock: ILockStore) -> None:
         self._catalog = catalog
         self._compute = compute
         self._lock = lock
+
+    def configure(self, declaration: InputDeclaration) -> IngestRecord:
+        """Resolve an input against the warehouse and persist it to dbport.lock.
+
+        This validates that the configured input exists, resolves the effective
+        version and snapshot, computes the row count to persist, and then writes
+        the resulting IngestRecord through the lock adapter.
+        """
+        record = self._catalog.inspect_input(declaration)
+        self._lock.write_ingest_record(record)
+        return record
 
     def execute(self, declaration: InputDeclaration) -> IngestRecord:
         """Load (or skip) the input. Returns the resulting IngestRecord."""
@@ -63,9 +72,9 @@ class IngestService:
             raise
         except Exception as exc:
             logger.debug(
-                "resolve_input_snapshot failed for %s (%s); "
-                "falling back to current_snapshot()",
-                table_address, exc,
+                "resolve_input_snapshot failed for %s (%s); falling back to current_snapshot()",
+                table_address,
+                exc,
             )
 
         if resolved_snap_id is None:
@@ -76,7 +85,9 @@ class IngestService:
 
         logger.debug(
             "Resolved %s → version=%s snapshot_id=%s",
-            table_address, resolved_version, resolved_snap_id,
+            table_address,
+            resolved_version,
+            resolved_snap_id,
         )
 
         # ------------------------------------------------------------------
@@ -100,7 +111,9 @@ class IngestService:
                 cb.log(f"Skipping {table_address} (snapshot unchanged)")
             logger.debug(
                 "Skipping %s (snapshot unchanged: %s version=%s)",
-                table_address, resolved_snap_id, resolved_version,
+                table_address,
+                resolved_snap_id,
+                resolved_version,
             )
             return current_record  # type: ignore[return-value]
 
@@ -109,14 +122,18 @@ class IngestService:
         # ------------------------------------------------------------------
         logger.debug(
             "Loading %s (version=%s snapshot=%s)",
-            table_address, resolved_version, resolved_snap_id,
+            table_address,
+            resolved_version,
+            resolved_snap_id,
         )
         rows_loaded = self._catalog.ingest_into_compute(
             declaration, self._compute, snapshot_id=resolved_snap_id
         )
         logger.debug(
             "Loaded %d rows into %s.%s",
-            rows_loaded, schema_name, table_name,
+            rows_loaded,
+            schema_name,
+            table_name,
         )
 
         # ------------------------------------------------------------------

--- a/src/dbport/application/services/run.py
+++ b/src/dbport/application/services/run.py
@@ -12,6 +12,54 @@ from ...domain.ports.lock import ILockStore
 logger = logging.getLogger(__name__)
 
 _SUPPORTED_EXTENSIONS = {".sql", ".py"}
+DEFAULT_RUN_HOOK = "main.py"
+
+
+def resolve_run_hook(lock: ILockStore) -> str:
+    """Return the configured run hook or the default model entrypoint."""
+    return lock.read_run_hook() or DEFAULT_RUN_HOOK
+
+
+def execute_hook(port: Any, hook: str) -> None:
+    """Execute a hook file against the active DBPort instance."""
+    ext = Path(hook).suffix.lower()
+
+    if ext == ".sql":
+        port.execute(hook)
+        return
+    if ext == ".py":
+        _exec_python_hook(port, hook)
+        return
+
+    raise ValueError(
+        f"Unsupported run hook extension '{ext}'. "
+        f"Supported: {', '.join(sorted(_SUPPORTED_EXTENSIONS))}"
+    )
+
+
+def _exec_python_hook(port: Any, hook: str) -> None:
+    """Execute a Python hook file with ``port`` available in scope.
+
+    If the hook defines a top-level ``run(port)`` callable, invoke it after
+    module execution. ``__name__`` is set to ``"__dbport_hook__"`` so that
+    standalone ``if __name__ == "__main__"`` blocks are skipped during CLI
+    execution while still working when the file is run directly.
+    """
+    path = Path(hook)
+    if not path.is_absolute():
+        path = Path(port._dataset.model_root) / path
+    logger.info("Executing Python hook: %s", path)
+    code = path.read_text(encoding="utf-8")
+    namespace: dict[str, Any] = {
+        "port": port,
+        "__file__": str(path),
+        "__name__": "__dbport_hook__",
+    }
+    exec(compile(code, str(path), "exec"), namespace)  # noqa: S102
+
+    hook_runner = namespace.get("run")
+    if callable(hook_runner):
+        hook_runner(port)
 
 
 class RunService:
@@ -44,12 +92,7 @@ class RunService:
             version: If provided, ``port.publish()`` is called after the hook.
             mode: Publish mode forwarded to ``port.publish()``.
         """
-        hook = self._lock.read_run_hook()
-        if not hook:
-            raise RuntimeError(
-                "No run_hook configured for this model. "
-                "Set it with: dbp config run-hook <path>"
-            )
+        hook = resolve_run_hook(self._lock)
 
         self._dispatch(port, hook)
 
@@ -58,23 +101,4 @@ class RunService:
 
     def _dispatch(self, port: Any, hook: str) -> None:
         """Route hook execution by file extension."""
-        ext = Path(hook).suffix.lower()
-
-        if ext == ".sql":
-            port.execute(hook)
-        elif ext == ".py":
-            self._exec_python(port, hook)
-        else:
-            raise ValueError(
-                f"Unsupported run hook extension '{ext}'. "
-                f"Supported: {', '.join(sorted(_SUPPORTED_EXTENSIONS))}"
-            )
-
-    def _exec_python(self, port: Any, hook: str) -> None:
-        """Execute a Python hook file with ``port`` available in scope."""
-        path = Path(hook)
-        if not path.is_absolute():
-            path = Path(port._dataset.model_root) / path
-        logger.info("Executing Python hook: %s", path)
-        code = path.read_text(encoding="utf-8")
-        exec(compile(code, str(path), "exec"), {"port": port, "__file__": str(path)})  # noqa: S102
+        execute_hook(port, hook)

--- a/src/dbport/application/services/schema.py
+++ b/src/dbport/application/services/schema.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ...domain.entities.schema import ColumnDef, DatasetSchema, SqlDdl
 from ...domain.ports.compute import ICompute
 from ...domain.ports.lock import ILockStore
+
+if TYPE_CHECKING:
+    from ...domain.ports.catalog import ICatalog
+
+logger = logging.getLogger(__name__)
 
 
 class DefineSchemaService:
@@ -24,6 +31,16 @@ class DefineSchemaService:
     def __init__(self, compute: ICompute, lock: ILockStore) -> None:
         self._compute = compute
         self._lock = lock
+        self._catalog: ICatalog | None = None
+        self._table_address: str | None = None
+
+    def with_catalog(
+        self, catalog: ICatalog | None, table_address: str | None
+    ) -> "DefineSchemaService":
+        """Attach optional warehouse context for early schema drift checks."""
+        self._catalog = catalog
+        self._table_address = table_address
+        return self
 
     def execute(self, ddl_or_path: str, base_dir: str) -> DatasetSchema:
         """Apply and persist the schema. Returns the parsed DatasetSchema."""
@@ -55,6 +72,9 @@ class DefineSchemaService:
         self._compute.execute(ddl)
         table_address = m.group(1)
 
+        if self._catalog is not None and self._table_address is not None:
+            self._check_warehouse_drift(table_address)
+
         parts = table_address.split(".", 1)
         if len(parts) == 2:
             schema_name, table_name = parts
@@ -71,10 +91,29 @@ class DefineSchemaService:
         ).fetchall()
 
         columns = tuple(
-            ColumnDef(name=str(row[0]), pos=i, sql_type=str(row[1]))
-            for i, row in enumerate(rows)
+            ColumnDef(name=str(row[0]), pos=i, sql_type=str(row[1])) for i, row in enumerate(rows)
         )
 
         schema = DatasetSchema(ddl=SqlDdl(statement=ddl), columns=columns, source="local")
         self._lock.write_schema(schema)
         return schema
+
+    def _check_warehouse_drift(self, ddl_table_address: str) -> None:
+        """Compare the local DuckDB schema against the warehouse; raise on drift."""
+        from ...adapters.secondary.catalog.drift import SchemaDriftError, check_schema_drift
+
+        assert self._catalog is not None  # noqa: S101
+        assert self._table_address is not None  # noqa: S101
+
+        try:
+            if not self._catalog.table_exists(self._table_address):
+                return
+
+            warehouse_arrow = self._catalog.load_arrow_schema(self._table_address)
+            reader = self._compute.to_arrow_batches(f"SELECT * FROM {ddl_table_address} LIMIT 0")
+            local_arrow = getattr(reader, "schema_arrow", None) or reader.schema
+            check_schema_drift(local_arrow, warehouse_arrow)
+        except SchemaDriftError:
+            raise
+        except Exception as exc:
+            logger.warning("Schema drift check skipped: %s", exc)

--- a/src/dbport/application/services/sync.py
+++ b/src/dbport/application/services/sync.py
@@ -36,6 +36,14 @@ class SyncService:
         self._sync_output_table(table_address)
         self._sync_inputs()
 
+    def sync_output_table(self, table_address: str) -> None:
+        """Sync only the output table definition into local DuckDB."""
+        self._sync_output_table(table_address)
+
+    def sync_inputs(self) -> None:
+        """Sync only configured inputs into local DuckDB."""
+        self._sync_inputs()
+
     def _sync_output_table(self, table_address: str) -> None:
         """Create or recreate the output table from lock schema.
 
@@ -89,6 +97,7 @@ class SyncService:
             except Exception as exc:
                 cb = progress_callback.get(None)
                 if cb:
+                    cb.log(f"Failed to sync {record.table_address}: {exc}")
                     cb.failed(f"Failed to sync {record.table_address}")
                 logger.warning(
                     "Failed to sync input %s: %s",

--- a/src/dbport/cli/commands/check.py
+++ b/src/dbport/cli/commands/check.py
@@ -1,4 +1,4 @@
-"""dbp check — verify project health."""
+"""dbp status check — verify project health."""
 
 from __future__ import annotations
 
@@ -19,23 +19,28 @@ def check_cmd(
 
     cli_ctx = get_cli_ctx(ctx)
 
-    with cli_error_handler("check", json_output=cli_ctx.json_output):
+    with cli_error_handler("status check", json_output=cli_ctx.json_output):
         checks: list[dict] = []
 
         # 1. Lockfile
         lock_ok = cli_ctx.lockfile_path.exists()
-        checks.append({
-            "name": "lockfile",
-            "status": "pass" if lock_ok else "fail",
-            "detail": str(cli_ctx.lockfile_path),
-        })
+        checks.append(
+            {
+                "name": "lockfile",
+                "status": "pass" if lock_ok else "fail",
+                "detail": str(cli_ctx.lockfile_path),
+            }
+        )
 
         # 2. Lockfile readable
         if lock_ok:
             try:
                 import tomllib
+
                 tomllib.loads(cli_ctx.lockfile_path.read_text(encoding="utf-8"))
-                checks.append({"name": "lockfile_readable", "status": "pass", "detail": "valid TOML"})
+                checks.append(
+                    {"name": "lockfile_readable", "status": "pass", "detail": "valid TOML"}
+                )
             except Exception as exc:
                 checks.append({"name": "lockfile_readable", "status": "fail", "detail": str(exc)})
 
@@ -43,17 +48,21 @@ def check_cmd(
         duckdb_ok = False
         try:
             import duckdb
+
             conn = duckdb.connect(":memory:")
             conn.execute("SELECT 1")
             conn.close()
             duckdb_ok = True
-            checks.append({"name": "duckdb", "status": "pass", "detail": f"duckdb {duckdb.__version__}"})
+            checks.append(
+                {"name": "duckdb", "status": "pass", "detail": f"duckdb {duckdb.__version__}"}
+            )
         except Exception as exc:
             checks.append({"name": "duckdb", "status": "fail", "detail": str(exc)})
 
         # 4. Credentials
         try:
             from ...infrastructure.credentials import WarehouseCreds
+
             creds = WarehouseCreds()
             missing = []
             if not creds.catalog_uri:
@@ -63,25 +72,34 @@ def check_cmd(
             if not creds.warehouse:
                 missing.append("ICEBERG_WAREHOUSE")
             if missing:
-                checks.append({
-                    "name": "credentials",
-                    "status": "warn",
-                    "detail": f"missing: {', '.join(missing)}",
-                })
+                checks.append(
+                    {
+                        "name": "credentials",
+                        "status": "warn",
+                        "detail": f"missing: {', '.join(missing)}",
+                    }
+                )
             else:
-                checks.append({"name": "credentials", "status": "pass", "detail": "all required vars set"})
+                checks.append(
+                    {"name": "credentials", "status": "pass", "detail": "all required vars set"}
+                )
         except Exception:
             # Pydantic validation error when env vars are missing
             import os
+
             missing = []
             for var in ("ICEBERG_REST_URI", "ICEBERG_CATALOG_TOKEN", "ICEBERG_WAREHOUSE"):
                 if not os.environ.get(var):
                     missing.append(var)
-            checks.append({
-                "name": "credentials",
-                "status": "warn",
-                "detail": f"missing env vars: {', '.join(missing)}" if missing else "validation failed",
-            })
+            checks.append(
+                {
+                    "name": "credentials",
+                    "status": "warn",
+                    "detail": f"missing env vars: {', '.join(missing)}"
+                    if missing
+                    else "validation failed",
+                }
+            )
 
         # 5. Python dependencies
         dep_issues = []
@@ -91,7 +109,13 @@ def check_cmd(
             except ImportError:
                 dep_issues.append(pkg)
         if dep_issues:
-            checks.append({"name": "dependencies", "status": "fail", "detail": f"missing: {', '.join(dep_issues)}"})
+            checks.append(
+                {
+                    "name": "dependencies",
+                    "status": "fail",
+                    "detail": f"missing: {', '.join(dep_issues)}",
+                }
+            )
         else:
             checks.append({"name": "dependencies", "status": "pass", "detail": "all present"})
 
@@ -101,7 +125,7 @@ def check_cmd(
         overall_ok = not has_fail and (not has_warn if strict else True)
 
         if cli_ctx.json_output:
-            print_json("check", {"checks": checks, "ok": overall_ok}, ok=overall_ok)
+            print_json("status check", {"checks": checks, "ok": overall_ok}, ok=overall_ok)
             if not overall_ok:
                 sys.exit(1)
             return

--- a/src/dbport/cli/commands/config.py
+++ b/src/dbport/cli/commands/config.py
@@ -6,7 +6,6 @@ in ``dbport.lock``.
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
 import typer
@@ -14,30 +13,208 @@ import typer
 from ..errors import cli_error_handler
 from ..render import print_error, print_info, print_json, print_success, print_table, print_warning
 
+CONFIG_HELP = "Manage repo defaults and model-specific configuration."
+
 config_app = typer.Typer(
     name="config",
-    help="Manage project configuration.",
+    help=CONFIG_HELP,
     no_args_is_help=True,
 )
 
+default_app = typer.Typer(
+    name="default",
+    help="Manage repo default settings.",
+    no_args_is_help=True,
+)
 
-@config_app.command(name="default")
-def default_cmd(
+model_app = typer.Typer(
+    name="model",
+    help="Manage configuration for a specific model.",
+    no_args_is_help=True,
+)
+
+columns_app = typer.Typer(
+    name="columns",
+    help="Manage column metadata for a specific model.",
+    no_args_is_help=False,
+)
+
+
+@default_app.command("model")
+def default_model_cmd(
     ctx: typer.Context,
-    model_key: str | None = typer.Argument(None, help="Model key (agency.dataset_id) to set as default."),
+    model_key: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
 ) -> None:
     """Show or set the default model for this project."""
-    from ..context import read_default_model, read_lock_models, write_default_model
     from ..main import get_cli_ctx
 
     cli_ctx = get_cli_ctx(ctx)
+    _handle_default_model(cli_ctx, model_key)
 
-    with cli_error_handler("config default", json_output=cli_ctx.json_output):
+
+@default_app.command("folder")
+def default_folder_cmd(
+    ctx: typer.Context,
+    folder: str | None = typer.Argument(None, help="Models folder relative to project root."),
+) -> None:
+    """Show or set the default models folder for new models."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    _handle_default_folder(cli_ctx, folder)
+
+
+@default_app.command("hook")
+def default_hook_cmd(
+    ctx: typer.Context,
+    hook_path: str | None = typer.Argument(None, help="Path to run hook file."),
+) -> None:
+    """Show or set the run hook for the resolved model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    _handle_default_hook(cli_ctx, hook_path)
+
+
+@model_app.callback()
+def model_callback(
+    ctx: typer.Context,
+    model_key: str = typer.Argument(..., help="Model key (agency.dataset_id)."),
+) -> None:
+    """Select the model to configure."""
+    ctx.ensure_object(dict)
+    ctx.obj["config_model_key"] = model_key
+
+
+@model_app.command("version")
+def model_version_cmd(
+    ctx: typer.Context,
+    version: str | None = typer.Argument(None, help="Version string to set."),
+) -> None:
+    """Show or set the configured version for a model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    model_key = _get_selected_model_key(ctx)
+    _handle_version_for_model(cli_ctx, model_key, version)
+
+
+@model_app.command("input")
+def model_input_cmd(
+    ctx: typer.Context,
+    dataset: str | None = typer.Argument(None, help="Table address to configure as input."),
+    filters: list[str] = typer.Option(
+        None,
+        "--filter",
+        help="Equality filter as key=value. Repeatable.",
+    ),
+    version: str | None = typer.Option(None, "--version", help="Pinned dataset version to load."),
+    load: bool = typer.Option(
+        False,
+        "--load",
+        help="Load the configured input immediately after persisting it.",
+    ),
+) -> None:
+    """Show configured inputs or add one, optionally loading it."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    model_key = _get_selected_model_key(ctx)
+    if dataset is None:
+        _handle_inputs_show(cli_ctx, model_key)
+        return
+
+    _handle_input_add(
+        cli_ctx,
+        model_key,
+        dataset=dataset,
+        filters=filters,
+        version=version,
+        load=load,
+    )
+
+
+@columns_app.callback(invoke_without_command=True)
+def model_columns_cmd(
+    ctx: typer.Context,
+) -> None:
+    """Show current column metadata for a model."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    model_key = _get_selected_model_key(ctx)
+    _handle_columns_show(cli_ctx, model_key)
+
+
+@columns_app.command("set")
+def model_columns_set_cmd(
+    ctx: typer.Context,
+    column: str = typer.Argument(..., help="Column name to inspect or configure."),
+    codelist_id: str | None = typer.Option(None, "--id", help="Codelist identifier."),
+    codelist_type: str | None = typer.Option(None, "--type", help="Codelist type."),
+    codelist_kind: str | None = typer.Option(None, "--kind", help="Codelist kind."),
+    codelist_labels: str | None = typer.Option(None, "--labels", help="JSON labels."),
+) -> None:
+    """Set column metadata for a model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    model_key = _get_selected_model_key(ctx)
+    _handle_columns_set(
+        cli_ctx,
+        model_key,
+        column=column,
+        codelist_id=codelist_id,
+        codelist_type=codelist_type,
+        codelist_kind=codelist_kind,
+        codelist_labels=codelist_labels,
+    )
+
+
+@columns_app.command("attach")
+def model_attach_cmd(
+    ctx: typer.Context,
+    column: str = typer.Argument(..., help="Column name to attach a codelist to."),
+    table: str = typer.Argument(..., help="DuckDB table address to use as codelist source."),
+) -> None:
+    """Attach a table as the codelist source for a column."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    model_key = _get_selected_model_key(ctx)
+    _handle_attach_for_model(cli_ctx, model_key, column, table)
+
+
+config_app.add_typer(default_app, name="default")
+config_app.add_typer(model_app, name="model")
+model_app.add_typer(columns_app, name="columns")
+
+from . import schema as schema_commands  # noqa: E402
+
+model_app.command("schema")(schema_commands.schema_cmd)
+
+
+def _get_selected_model_key(ctx: typer.Context) -> str:
+    if ctx.obj and "config_model_key" in ctx.obj:
+        return ctx.obj["config_model_key"]
+    if ctx.parent is not None:
+        return _get_selected_model_key(ctx.parent)
+    raise typer.BadParameter("Missing model key. Use: dbp config model <model_key> ...")
+
+
+def _handle_default_model(cli_ctx, model_key: str | None) -> None:
+    """Show or set the default model for this project."""
+    from ..context import read_default_model, read_lock_models, write_default_model
+
+    with cli_error_handler("config default model", json_output=cli_ctx.json_output):
         if model_key is None:
             # Show current default
             current = read_default_model(cli_ctx.lockfile_path)
             if cli_ctx.json_output:
-                print_json("config default", {"default_model": current})
+                print_json("config default model", {"default_model": current})
             elif current:
                 print_info(f"Default model: {current}")
             else:
@@ -56,32 +233,25 @@ def default_cmd(
             write_default_model(cli_ctx.lockfile_path, model_key)
 
             if cli_ctx.json_output:
-                print_json("config default", {"default_model": model_key})
+                print_json("config default model", {"default_model": model_key})
             else:
                 print_success(f"Default model set to: {model_key}")
 
 
-@config_app.command(name="folder")
-def folder_cmd(
-    ctx: typer.Context,
-    folder: str | None = typer.Argument(None, help="Models folder relative to project root (e.g. 'models' or 'examples')."),
-) -> None:
+def _handle_default_folder(cli_ctx, folder: str | None) -> None:
     """Show or set the default models folder for new models.
 
     New models created with `dbp init` are scaffolded inside this folder.
     Default: 'models'.
     """
     from ..context import read_models_folder, write_models_folder
-    from ..main import get_cli_ctx
 
-    cli_ctx = get_cli_ctx(ctx)
-
-    with cli_error_handler("config folder", json_output=cli_ctx.json_output):
+    with cli_error_handler("config default folder", json_output=cli_ctx.json_output):
         if folder is None:
             # Show current models folder
             current = read_models_folder(cli_ctx.lockfile_path)
             if cli_ctx.json_output:
-                print_json("config folder", {"models_folder": current})
+                print_json("config default folder", {"models_folder": current})
             else:
                 print_info(f"Models folder: {current}")
         else:
@@ -90,52 +260,60 @@ def folder_cmd(
             write_models_folder(cli_ctx.lockfile_path, folder)
 
             if cli_ctx.json_output:
-                print_json("config folder", {"models_folder": folder})
+                print_json("config default folder", {"models_folder": folder})
             else:
                 print_success(f"Models folder set to: {folder}")
 
 
-@config_app.command(name="run-hook")
-def run_hook_cmd(
-    ctx: typer.Context,
-    hook_path: str | None = typer.Argument(None, help="Path to run hook file (e.g. sql/main.sql or run.py)."),
-) -> None:
+def _handle_default_hook(cli_ctx, hook_path: str | None) -> None:
     """Show or set the run hook for the resolved model."""
     from ..context import resolve_model_paths
-    from ..main import get_cli_ctx
 
-    cli_ctx = get_cli_ctx(ctx)
-
-    with cli_error_handler("config run-hook", json_output=cli_ctx.json_output):
+    with cli_error_handler("config default hook", json_output=cli_ctx.json_output):
         if hook_path is None:
             # Show current run_hook
             paths = resolve_model_paths(cli_ctx)
             from ...adapters.secondary.lock.toml import TomlLockAdapter
+            from ...application.services.run import resolve_run_hook
 
             model_key = f"{paths.agency}.{paths.dataset_id}"
-            raw_root = str(Path(paths.model_root).relative_to(cli_ctx.project_path)) if Path(paths.model_root).is_absolute() else paths.model_root
-            raw_db = str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path)) if Path(paths.duckdb_path).is_absolute() else paths.duckdb_path
+            raw_root = (
+                str(Path(paths.model_root).relative_to(cli_ctx.project_path))
+                if Path(paths.model_root).is_absolute()
+                else paths.model_root
+            )
+            raw_db = (
+                str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path))
+                if Path(paths.duckdb_path).is_absolute()
+                else paths.duckdb_path
+            )
             adapter = TomlLockAdapter(
                 cli_ctx.lockfile_path,
                 model_key=model_key,
                 model_root=raw_root,
                 duckdb_path=raw_db,
             )
-            current = adapter.read_run_hook()
+            current = resolve_run_hook(adapter)
             if cli_ctx.json_output:
-                print_json("config run-hook", {"run_hook": current, "model": model_key})
-            elif current:
-                print_info(f"Run hook for {model_key}: {current}")
+                print_json("config default hook", {"run_hook": current, "model": model_key})
             else:
-                print_info(f"No run hook set for {model_key}.")
+                print_info(f"Run hook for {model_key}: {current}")
         else:
             # Set run_hook
             paths = resolve_model_paths(cli_ctx)
             from ...adapters.secondary.lock.toml import TomlLockAdapter
 
             model_key = f"{paths.agency}.{paths.dataset_id}"
-            raw_root = str(Path(paths.model_root).relative_to(cli_ctx.project_path)) if Path(paths.model_root).is_absolute() else paths.model_root
-            raw_db = str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path)) if Path(paths.duckdb_path).is_absolute() else paths.duckdb_path
+            raw_root = (
+                str(Path(paths.model_root).relative_to(cli_ctx.project_path))
+                if Path(paths.model_root).is_absolute()
+                else paths.model_root
+            )
+            raw_db = (
+                str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path))
+                if Path(paths.duckdb_path).is_absolute()
+                else paths.duckdb_path
+            )
             adapter = TomlLockAdapter(
                 cli_ctx.lockfile_path,
                 model_key=model_key,
@@ -154,61 +332,28 @@ def run_hook_cmd(
             adapter.write_run_hook(normalized)
 
             if cli_ctx.json_output:
-                print_json("config run-hook", {"run_hook": normalized, "model": model_key})
+                print_json("config default hook", {"run_hook": normalized, "model": model_key})
             else:
                 print_success(f"Run hook set to: {normalized}")
 
 
-@config_app.command(name="version")
-def version_cmd(
-    ctx: typer.Context,
-    version: str | None = typer.Argument(None, help="Version string to set (e.g. 2026-03-16)."),
-) -> None:
-    """Show or set the default publish version for the resolved model."""
-    from ..context import resolve_model_paths
-    from ..main import get_cli_ctx
-
-    cli_ctx = get_cli_ctx(ctx)
-
-    with cli_error_handler("config version", json_output=cli_ctx.json_output):
-        paths = resolve_model_paths(cli_ctx)
-        from ...adapters.secondary.lock.toml import TomlLockAdapter
-
-        model_key = f"{paths.agency}.{paths.dataset_id}"
-        raw_root = str(Path(paths.model_root).relative_to(cli_ctx.project_path)) if Path(paths.model_root).is_absolute() else paths.model_root
-        raw_db = str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path)) if Path(paths.duckdb_path).is_absolute() else paths.duckdb_path
-        adapter = TomlLockAdapter(
-            cli_ctx.lockfile_path,
-            model_key=model_key,
-            model_root=raw_root,
-            duckdb_path=raw_db,
-        )
-
-        if version is None:
-            current = adapter.read_version()
-            if cli_ctx.json_output:
-                print_json("config version", {"version": current, "model": model_key})
-            elif current:
-                print_info(f"Version for {model_key}: {current}")
-            else:
-                print_info(f"No version set for {model_key}.")
-        else:
-            adapter.write_version(version)
-            if cli_ctx.json_output:
-                print_json("config version", {"version": version, "model": model_key})
-            else:
-                print_success(f"Version set to: {version}")
-
-
 def _make_lock_adapter(cli_ctx):
     """Create a TomlLockAdapter for the resolved model."""
-    from ..context import resolve_model_paths
     from ...adapters.secondary.lock.toml import TomlLockAdapter
+    from ..context import resolve_model_paths
 
     paths = resolve_model_paths(cli_ctx)
     model_key = f"{paths.agency}.{paths.dataset_id}"
-    raw_root = str(Path(paths.model_root).relative_to(cli_ctx.project_path)) if Path(paths.model_root).is_absolute() else paths.model_root
-    raw_db = str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path)) if Path(paths.duckdb_path).is_absolute() else paths.duckdb_path
+    raw_root = (
+        str(Path(paths.model_root).relative_to(cli_ctx.project_path))
+        if Path(paths.model_root).is_absolute()
+        else paths.model_root
+    )
+    raw_db = (
+        str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path))
+        if Path(paths.duckdb_path).is_absolute()
+        else paths.duckdb_path
+    )
     adapter = TomlLockAdapter(
         cli_ctx.lockfile_path,
         model_key=model_key,
@@ -218,279 +363,330 @@ def _make_lock_adapter(cli_ctx):
     return adapter, model_key
 
 
-@config_app.command(name="meta")
-def meta_cmd(
-    ctx: typer.Context,
-    column: str | None = typer.Argument(None, help="Column name to configure."),
-    codelist_id: str | None = typer.Option(None, "--id", help="Codelist identifier."),
-    codelist_type: str | None = typer.Option(None, "--type", help="Codelist type (e.g. categorical, hierarchical)."),
-    codelist_kind: str | None = typer.Option(None, "--kind", help="Codelist kind (e.g. reference, derived)."),
-    codelist_labels: str | None = typer.Option(None, "--labels", help="JSON labels (e.g. '{\"en\": \"Geography\"}')."),
-) -> None:
-    """Show or set codelist metadata for output columns."""
-    from ..main import get_cli_ctx
+def _make_lock_adapter_for_model(cli_ctx, explicit_model_key: str):
+    """Create a TomlLockAdapter for an explicitly selected model key."""
+    from ...adapters.secondary.lock.toml import TomlLockAdapter
+    from ..context import read_lock_models, resolve_model_paths_from_data
 
-    cli_ctx = get_cli_ctx(ctx)
+    models = read_lock_models(cli_ctx.lockfile_path)
+    if explicit_model_key not in models:
+        available = list(models.keys()) if models else []
+        print_error(
+            f"Model '{explicit_model_key}' not found in {cli_ctx.lockfile_path}. "
+            f"Available: {available}"
+        )
+        raise typer.Exit(1)
 
-    with cli_error_handler("config meta", json_output=cli_ctx.json_output):
-        adapter, model_key = _make_lock_adapter(cli_ctx)
+    paths = resolve_model_paths_from_data(cli_ctx, models[explicit_model_key])
+    raw_root = (
+        str(Path(paths.model_root).relative_to(cli_ctx.project_path))
+        if Path(paths.model_root).is_absolute()
+        else paths.model_root
+    )
+    raw_db = (
+        str(Path(paths.duckdb_path).relative_to(cli_ctx.project_path))
+        if Path(paths.duckdb_path).is_absolute()
+        else paths.duckdb_path
+    )
+    adapter = TomlLockAdapter(
+        cli_ctx.lockfile_path,
+        model_key=explicit_model_key,
+        model_root=raw_root,
+        duckdb_path=raw_db,
+    )
+    return adapter, explicit_model_key
 
-        if column is None:
-            # Show all column metadata
-            entries = adapter.read_codelist_entries()
+
+def _handle_version_for_model(cli_ctx, model_key: str, version: str | None) -> None:
+    with cli_error_handler("config version", json_output=cli_ctx.json_output):
+        adapter, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+
+        if version is None:
+            current = adapter.read_version()
             if cli_ctx.json_output:
-                data = {
-                    name: {
-                        "codelist_id": e.codelist_id,
-                        "codelist_type": e.codelist_type,
-                        "codelist_kind": e.codelist_kind,
-                        "codelist_labels": e.codelist_labels,
-                        "attach_table": e.attach_table,
-                    }
-                    for name, e in entries.items()
-                }
-                print_json("config meta", {"model": model_key, "columns": data})
-            elif entries:
-                rows = []
-                for name, e in entries.items():
-                    rows.append([
-                        name,
-                        e.codelist_id or "",
-                        e.codelist_type or "",
-                        e.codelist_kind or "",
-                        e.attach_table or "",
-                    ])
-                print_table(
-                    f"Column metadata — {model_key}",
-                    ["Column", "ID", "Type", "Kind", "Attach"],
-                    rows,
-                )
+                print_json("config version", {"version": current, "model": resolved_model_key})
+            elif current:
+                print_info(f"Version for {resolved_model_key}: {current}")
             else:
-                print_info("No columns defined. Apply a schema first: dbp schema sql/create_output.sql")
+                print_info(f"No version set for {resolved_model_key}.")
             return
 
-        # Set metadata for a specific column
-        from ...domain.entities.codelist import CodelistEntry
+        adapter.write_version(version)
+        if cli_ctx.json_output:
+            print_json("config version", {"version": version, "model": resolved_model_key})
+        else:
+            print_success(f"Version set to: {version}")
 
-        entries = adapter.read_codelist_entries()
-        existing = entries.get(column)
-        if existing is None:
-            existing = CodelistEntry(
-                column_name=column, column_pos=0, codelist_id=column,
-            )
 
-        overrides: dict = {}
-        if codelist_id is not None:
-            overrides["codelist_id"] = codelist_id
-        if codelist_type is not None:
-            overrides["codelist_type"] = codelist_type
-        if codelist_kind is not None:
-            overrides["codelist_kind"] = codelist_kind
-        if codelist_labels is not None:
-            import json
-            overrides["codelist_labels"] = json.loads(codelist_labels)
+def _handle_inputs_show(cli_ctx, model_key: str) -> None:
+    from ...adapters.secondary.lock.toml import TomlLockAdapter
 
-        updated = existing.model_copy(update=overrides)
-        adapter.write_codelist_entry(updated)
+    with cli_error_handler("config input", json_output=cli_ctx.json_output):
+        adapter, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+        records = adapter.read_ingest_records()
 
         if cli_ctx.json_output:
-            print_json("config meta", {
+            data = [
+                {
+                    "table_address": record.table_address,
+                    "filters": record.filters,
+                    "version": record.version,
+                    "rows_loaded": record.rows_loaded,
+                    "last_snapshot_id": record.last_snapshot_id,
+                }
+                for record in records
+            ]
+            print_json("config input", {"model": resolved_model_key, "inputs": data})
+            return
+
+        if not records:
+            print_info(f"No inputs configured for {resolved_model_key}.")
+            return
+
+        rows = []
+        for record in records:
+            filter_text = ""
+            if record.filters:
+                filter_text = ", ".join(f"{key}={value}" for key, value in record.filters.items())
+            rows.append(
+                [
+                    record.table_address,
+                    record.version or "",
+                    filter_text,
+                    str(record.rows_loaded or ""),
+                ]
+            )
+
+        print_table(
+            f"Inputs — {resolved_model_key}",
+            ["Table", "Version", "Filters", "Rows"],
+            rows,
+        )
+
+
+def _handle_input_add(
+    cli_ctx,
+    model_key: str,
+    *,
+    dataset: str,
+    filters: list[str] | None,
+    version: str | None,
+    load: bool,
+) -> None:
+    from ...adapters.primary.client import DBPort
+    from ..context import read_lock_models, resolve_model_paths_from_data
+
+    with cli_error_handler("config input", json_output=cli_ctx.json_output):
+        _, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+        parsed_filters = _parse_input_filters(filters)
+        model_data = read_lock_models(cli_ctx.lockfile_path)[resolved_model_key]
+        paths = resolve_model_paths_from_data(cli_ctx, model_data)
+        with DBPort(
+            agency=paths.agency,
+            dataset_id=paths.dataset_id,
+            lock_path=paths.lock_path,
+            duckdb_path=paths.duckdb_path,
+            model_root=paths.model_root,
+            load_inputs_on_init=False,
+        ) as port:
+            if load:
+                resolved_record = port.load(
+                    dataset,
+                    filters=parsed_filters,
+                    version=version,
+                )
+            else:
+                resolved_record = port.configure_input(
+                    dataset,
+                    filters=parsed_filters,
+                    version=version,
+                )
+
+        if cli_ctx.json_output:
+            print_json(
+                "config input",
+                {
+                    "model": resolved_model_key,
+                    "table_address": dataset,
+                    "filters": parsed_filters,
+                    "version": resolved_record.version,
+                    "last_snapshot_id": resolved_record.last_snapshot_id,
+                    "last_snapshot_timestamp_ms": resolved_record.last_snapshot_timestamp_ms,
+                    "rows_loaded": resolved_record.rows_loaded,
+                    "load": load,
+                },
+            )
+        else:
+            if load:
+                print_success(f"Configured and loaded input {dataset} for {resolved_model_key}")
+            else:
+                print_success(f"Configured input {dataset} for {resolved_model_key}")
+
+
+def _parse_input_filters(filters: list[str] | None) -> dict[str, str] | None:
+    if not filters:
+        return None
+
+    parsed: dict[str, str] = {}
+    for item in filters:
+        if "=" not in item:
+            raise typer.BadParameter(
+                f"Invalid --filter '{item}'. Expected key=value.",
+                param_hint="--filter",
+            )
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise typer.BadParameter(
+                f"Invalid --filter '{item}'. Key must not be empty.",
+                param_hint="--filter",
+            )
+        parsed[key] = value
+    return parsed
+
+
+def _handle_columns_show(cli_ctx, model_key: str) -> None:
+    with cli_error_handler("config columns", json_output=cli_ctx.json_output):
+        adapter, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+        entries = adapter.read_codelist_entries()
+        if cli_ctx.json_output:
+            data = {
+                name: {
+                    "codelist_id": entry.codelist_id,
+                    "codelist_type": entry.codelist_type,
+                    "codelist_kind": entry.codelist_kind,
+                    "codelist_labels": entry.codelist_labels,
+                    "attach_table": entry.attach_table,
+                }
+                for name, entry in entries.items()
+            }
+            print_json("config columns", {"model": resolved_model_key, "columns": data})
+        elif entries:
+            rows = [
+                [
+                    name,
+                    entry.codelist_id or "",
+                    entry.codelist_type or "",
+                    entry.codelist_kind or "",
+                    entry.attach_table or "",
+                ]
+                for name, entry in entries.items()
+            ]
+            print_table(
+                f"Column metadata — {resolved_model_key}",
+                ["Column", "ID", "Type", "Kind", "Attach"],
+                rows,
+            )
+        else:
+            print_info(
+                "No columns defined. Apply a schema first: "
+                f"dbp config model {resolved_model_key} schema sql/create_output.sql"
+            )
+
+
+def _handle_columns_set(
+    cli_ctx,
+    model_key: str,
+    *,
+    column: str,
+    codelist_id: str | None,
+    codelist_type: str | None,
+    codelist_kind: str | None,
+    codelist_labels: str | None,
+) -> None:
+    with cli_error_handler("config columns", json_output=cli_ctx.json_output):
+        adapter, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+        overrides = _parse_column_override_args(
+            codelist_id=codelist_id,
+            codelist_type=codelist_type,
+            codelist_kind=codelist_kind,
+            codelist_labels=codelist_labels,
+        )
+        _update_column_metadata(cli_ctx, adapter, resolved_model_key, column, overrides)
+
+
+def _parse_column_override_args(
+    *,
+    codelist_id: str | None,
+    codelist_type: str | None,
+    codelist_kind: str | None,
+    codelist_labels: str | None,
+) -> dict:
+    overrides: dict = {}
+    if codelist_id is not None:
+        overrides["codelist_id"] = codelist_id
+    if codelist_type is not None:
+        overrides["codelist_type"] = codelist_type
+    if codelist_kind is not None:
+        overrides["codelist_kind"] = codelist_kind
+    if codelist_labels is not None:
+        import json
+
+        overrides["codelist_labels"] = json.loads(codelist_labels)
+
+    return overrides
+
+
+def _handle_attach_for_model(cli_ctx, model_key: str, column: str, table: str) -> None:
+    with cli_error_handler("config columns attach", json_output=cli_ctx.json_output):
+        adapter, resolved_model_key = _make_lock_adapter_for_model(cli_ctx, model_key)
+        _attach_column_table(cli_ctx, adapter, resolved_model_key, column, table)
+
+
+def _update_column_metadata(cli_ctx, adapter, model_key: str, column: str, overrides: dict) -> None:
+    from ...domain.entities.codelist import CodelistEntry
+
+    entries = adapter.read_codelist_entries()
+    existing = entries.get(column)
+    if existing is None:
+        existing = CodelistEntry(
+            column_name=column,
+            column_pos=0,
+            codelist_id=column,
+        )
+
+    updated = existing.model_copy(update=overrides)
+    adapter.write_codelist_entry(updated)
+
+    if cli_ctx.json_output:
+        print_json(
+            "config columns",
+            {
                 "column": column,
                 "model": model_key,
                 "codelist_id": updated.codelist_id,
                 "codelist_type": updated.codelist_type,
                 "codelist_kind": updated.codelist_kind,
-            })
-        else:
-            print_success(f"Updated metadata for column '{column}'")
+            },
+        )
+    else:
+        print_success(f"Updated metadata for column '{column}'")
 
 
-@config_app.command(name="attach")
-def attach_cmd(
-    ctx: typer.Context,
-    column: str = typer.Argument(help="Column name to attach codelist to."),
-    table: str = typer.Option(..., "--table", help="DuckDB table address to use as codelist source."),
-) -> None:
-    """Attach a DuckDB table as codelist source for a column."""
-    from ..main import get_cli_ctx
+def _attach_column_table(cli_ctx, adapter, model_key: str, column: str, table: str) -> None:
+    from ...domain.entities.codelist import CodelistEntry
 
-    cli_ctx = get_cli_ctx(ctx)
+    entries = adapter.read_codelist_entries()
+    existing = entries.get(column)
+    if existing is None:
+        existing = CodelistEntry(
+            column_name=column,
+            column_pos=0,
+            codelist_id=column,
+        )
 
-    with cli_error_handler("config attach", json_output=cli_ctx.json_output):
-        from ...domain.entities.codelist import CodelistEntry
+    updated = existing.model_copy(update={"attach_table": table})
+    adapter.write_codelist_entry(updated)
 
-        adapter, model_key = _make_lock_adapter(cli_ctx)
-
-        entries = adapter.read_codelist_entries()
-        existing = entries.get(column)
-        if existing is None:
-            existing = CodelistEntry(
-                column_name=column, column_pos=0, codelist_id=column,
-            )
-
-        updated = existing.model_copy(update={"attach_table": table})
-        adapter.write_codelist_entry(updated)
-
-        if cli_ctx.json_output:
-            print_json("config attach", {
+    if cli_ctx.json_output:
+        print_json(
+            "config columns attach",
+            {
                 "column": column,
                 "table": table,
                 "model": model_key,
-            })
-        else:
-            print_success(f"Attached '{table}' as codelist for column '{column}'")
-
-
-@config_app.command(name="info")
-def info_cmd(
-    ctx: typer.Context,
-    inputs: bool = typer.Option(False, "--inputs", help="Show input details."),
-    history: bool = typer.Option(False, "--history", help="Show publish history."),
-    raw: bool = typer.Option(False, "--raw", help="Show raw lock file TOML."),
-) -> None:
-    """Inspect persisted lock file state for the resolved model."""
-    from ..context import _resolve_model_data, read_default_model, read_lock_models
-    from ..main import get_cli_ctx
-
-    cli_ctx = get_cli_ctx(ctx)
-
-    with cli_error_handler("config info", json_output=cli_ctx.json_output):
-        # --raw: dump the entire lock file as-is
-        if raw:
-            if not cli_ctx.lockfile_path.exists():
-                print_warning("No dbport.lock found.")
-                return
-            content = cli_ctx.lockfile_path.read_text(encoding="utf-8")
-            if cli_ctx.json_output:
-                print_json("config info", {"raw": content})
-            else:
-                import sys
-                sys.stdout.write(content)
-            return
-
-        if not cli_ctx.lockfile_path.exists():
-            if cli_ctx.json_output:
-                print_json("config info", {"error": "No dbport.lock found."}, ok=False)
-            else:
-                print_warning("No dbport.lock found. Run 'dbp init' to create a project.")
-            return
-
-        models = read_lock_models(cli_ctx.lockfile_path)
-        if not models:
-            if cli_ctx.json_output:
-                print_json("config info", {"error": "No models in lock file."}, ok=False)
-            else:
-                print_warning("No models found in dbport.lock.")
-            return
-
-        # Resolve which model to inspect
-        model_data = _resolve_model_data(cli_ctx, models)
-        model_key = f"{model_data.get('agency', '?')}.{model_data.get('dataset_id', '?')}"
-        default_model = read_default_model(cli_ctx.lockfile_path)
-
-        model_inputs = model_data.get("inputs", [])
-        model_versions = model_data.get("versions", [])
-        schema = model_data.get("schema", {})
-
-        # JSON output
-        if cli_ctx.json_output:
-            data: dict = {
-                "default_model": default_model,
-                "model_key": model_key,
-                "agency": model_data.get("agency"),
-                "dataset_id": model_data.get("dataset_id"),
-                "model_root": model_data.get("model_root"),
-                "duckdb_path": model_data.get("duckdb_path"),
-                "schema_defined": bool(schema.get("ddl")),
-                "schema_source": schema.get("source"),
-                "column_count": len(schema.get("columns", [])),
-                "input_count": len(model_inputs),
-                "version_count": len(model_versions),
-            }
-            if inputs:
-                data["inputs"] = [
-                    {
-                        "table_address": inp.get("table_address"),
-                        "last_snapshot_id": inp.get("last_snapshot_id"),
-                        "last_snapshot_timestamp_ms": inp.get("last_snapshot_timestamp_ms"),
-                        "rows_loaded": inp.get("rows_loaded"),
-                        "filters": inp.get("filters"),
-                        "version": inp.get("version"),
-                    }
-                    for inp in model_inputs
-                ]
-            if history:
-                data["versions"] = [
-                    {
-                        "version": v.get("version"),
-                        "published_at": str(v.get("published_at", "")),
-                        "iceberg_snapshot_id": v.get("iceberg_snapshot_id"),
-                        "rows": v.get("rows"),
-                        "completed": v.get("completed"),
-                    }
-                    for v in model_versions
-                ]
-            print_json("config info", data)
-            return
-
-        # Human-readable output — summary always shown
-        print_info(f"[bold]Lock file:[/]     {cli_ctx.lockfile_path}")
-        print_info(f"[bold]Default model:[/] {default_model or '[dim]not set[/]'}")
-        print_info("")
-        print_info(f"[bold cyan]Model:[/] {model_key}")
-        print_info(f"  Agency:     {model_data.get('agency', '?')}")
-        print_info(f"  Dataset:    {model_data.get('dataset_id', '?')}")
-        print_info(f"  Model root: {model_data.get('model_root', '?')}")
-        print_info(f"  DuckDB:     {model_data.get('duckdb_path', '?')}")
-
-        if schema.get("ddl"):
-            col_count = len(schema.get("columns", []))
-            print_info(f"  Schema:     defined ({col_count} columns, source: {schema.get('source', '?')})")
-        else:
-            print_info("  Schema:     [dim]not defined[/]")
-
-        print_info(f"  Inputs:     {len(model_inputs)}")
-        latest = model_versions[-1].get("version", "?") if model_versions else "none"
-        print_info(f"  Versions:   {len(model_versions)} (latest: {latest})")
-
-        # --inputs: detailed input table
-        if inputs and model_inputs:
-            print_info("")
-            rows = []
-            for inp in model_inputs:
-                ts = inp.get("last_snapshot_timestamp_ms")
-                ts_str = ""
-                if ts:
-                    ts_str = datetime.fromtimestamp(ts / 1000).isoformat(timespec="seconds") if isinstance(ts, (int, float)) else str(ts)
-                filters = inp.get("filters")
-                filter_str = ", ".join(f"{k}={v}" for k, v in filters.items()) if filters else ""
-                rows.append([
-                    inp.get("table_address", "?"),
-                    str(inp.get("rows_loaded", "?")),
-                    str(inp.get("last_snapshot_id", ""))[:12],
-                    ts_str,
-                    filter_str,
-                ])
-            print_table(
-                f"Inputs — {model_key}",
-                ["Table", "Rows", "Snapshot ID", "Snapshot Time", "Filters"],
-                rows,
-            )
-
-        # --history: detailed version history table
-        if history and model_versions:
-            print_info("")
-            rows = []
-            for v in model_versions:
-                rows.append([
-                    v.get("version", "?"),
-                    str(v.get("published_at", "?")),
-                    str(v.get("iceberg_snapshot_id", ""))[:12],
-                    str(v.get("rows", "?")),
-                    "yes" if v.get("completed") else "no",
-                ])
-            print_table(
-                f"Version History — {model_key}",
-                ["Version", "Published At", "Snapshot ID", "Rows", "Completed"],
-                rows,
-            )
+            },
+        )
+    else:
+        print_success(f"Attached '{table}' as codelist for column '{column}'")

--- a/src/dbport/cli/commands/execute.py
+++ b/src/dbport/cli/commands/execute.py
@@ -1,4 +1,4 @@
-"""dbp execute — execute SQL transforms or script files."""
+"""dbp exec — execute SQL transforms or Python model hooks."""
 
 from __future__ import annotations
 
@@ -11,21 +11,22 @@ from ..errors import cli_error_handler
 from ..render import cli_progress, print_info, print_json, print_success
 
 
-def execute_cmd(
+def exec_cmd(
     ctx: typer.Context,
-    target: str | None = typer.Argument(None, help="Path to .sql file to execute."),
+    target: str | None = typer.Argument(None, help="Path to a .sql or .py file to execute."),
     timing: bool = typer.Option(False, "--timing", help="Print execution duration."),
 ) -> None:
-    """Execute SQL transforms in DuckDB."""
+    """Execute SQL transforms or Python model hooks."""
     from ..main import get_cli_ctx
 
     cli_ctx = get_cli_ctx(ctx)
 
-    with cli_error_handler("execute", json_output=cli_ctx.json_output):
+    with cli_error_handler("exec", json_output=cli_ctx.json_output):
         if not target:
-            raise RuntimeError("No target specified. Usage: dbp execute <path/to/file.sql>")
+            raise RuntimeError("No target specified. Usage: dbp exec <path/to/file.sql|py>")
 
         from ...adapters.primary.client import DBPort
+        from ...application.services.run import execute_hook
         from ...infrastructure.progress import progress_callback
 
         paths = resolve_model_paths(cli_ctx)
@@ -43,7 +44,7 @@ def execute_cmd(
                 cb = progress_callback.get(None)
                 if cb:
                     cb.started(f"Executing {target}")
-                port.execute(target)
+                execute_hook(port, target)
                 if cb:
                     cb.finished(f"Executed {target}")
 
@@ -51,7 +52,7 @@ def execute_cmd(
 
         if cli_ctx.json_output:
             data = {"target": target, "elapsed_seconds": round(elapsed, 3)}
-            print_json("execute", data)
+            print_json("exec", data)
         else:
             print_success(f"Executed {target}")
             if timing:

--- a/src/dbport/cli/commands/init.py
+++ b/src/dbport/cli/commands/init.py
@@ -1,4 +1,4 @@
-"""dbp init — create a new model scaffold or sync existing models."""
+"""dbp init — scaffold a new model."""
 
 from __future__ import annotations
 
@@ -6,16 +6,9 @@ from pathlib import Path
 
 import typer
 
-from ..context import read_lock_models, resolve_model_paths_from_data
+from ..context import read_lock_models
 from ..errors import cli_error_handler
-from ..render import (
-    cli_progress,
-    cli_tree_progress,
-    print_error,
-    print_info,
-    print_json,
-    print_success,
-)
+from ..render import cli_progress, print_error, print_info, print_json, print_success
 
 _SQL_TEMPLATE = """\
 -- Output schema for {dataset}
@@ -29,70 +22,72 @@ CREATE OR REPLACE TABLE {agency}.{dataset} (
 
 _MAIN_SQL_TEMPLATE = """\
 -- Main transform for {dataset}
--- This file is executed by `dbp execute`.
+-- This file is executed from `main.py` via `dbp run` or `dbp exec`.
 
 -- Example:
 -- INSERT INTO {agency}.{dataset}
 -- SELECT * FROM staging;
 """
 
-_RUN_PY_TEMPLATE = '''\
-"""Custom model logic for {dataset}."""
+_MAIN_PY_TEMPLATE = '''\
+"""Default model entrypoint for {dataset}."""
 
 from dbport import DBPort
 
 
-def main() -> None:
-    with DBPort(agency="{agency}", dataset_id="{dataset}") as port:
-        port.schema("sql/create_output.sql")
-        # port.load("namespace.table_name")
-        port.execute("sql/main.sql")
-        # port.publish(version="YYYY-MM-DD")
+def run(port) -> None:
+    """Execute the model with an active DBPort instance."""
+    port.schema("sql/create_output.sql")
+    # port.load("namespace.table_name")
+    port.execute("sql/main.sql")
 
 
 if __name__ == "__main__":
-    main()
+    with DBPort(agency="{agency}", dataset_id="{dataset}") as port:
+        run(port)
 '''
 
 
 def init_cmd(
     ctx: typer.Context,
     name: str | None = typer.Argument(None, help="Model key (agency.dataset) or new project name."),
-    template: str = typer.Option("sql", "--template", help="Template type: sql, python, or hybrid."),
+    template: str = typer.Option(
+        "sql", "--template", help="Template type: sql, python, or hybrid."
+    ),
     dataset: str | None = typer.Option(None, "--dataset", help="Output dataset ID."),
     agency: str | None = typer.Option(None, "--agency", help="Agency identifier."),
     path: str | None = typer.Option(None, "--path", help="Target directory (default: ./<name>)."),
     force: bool = typer.Option(False, "--force", help="Overwrite existing files."),
 ) -> None:
-    """Initialize or sync models.
-
-    Without arguments: syncs all models in the lock file.
-    With a model key (agency.dataset_id): syncs that specific model.
-    With a new name: scaffolds a new model and registers it in the lock file.
-    """
+    """Scaffold a new model and register it in the lock file."""
     from ..main import get_cli_ctx
 
     cli_ctx = get_cli_ctx(ctx)
 
     with cli_error_handler("init", json_output=cli_ctx.json_output):
-        models = read_lock_models(cli_ctx.lockfile_path)
-
-        # Resolve what the user wants: sync existing or scaffold new
-        model_key = _resolve_model_key(name, agency, dataset)
-
         if name is None and not agency and not dataset and not path:
-            # No args at all → sync all models
-            _sync_all_models(cli_ctx, models)
-        elif model_key and model_key in models:
-            # Model exists in lock → sync it
-            _sync_single_model(cli_ctx, model_key, models[model_key])
-        else:
-            # Model not in lock → scaffold new
-            _scaffold_model(cli_ctx, name or "dbport_project", template, dataset, agency, path, force)
+            print_error(
+                "No model name specified. Usage: dbp init <name>\n"
+                "To synchronize existing models, use: dbp model sync or dbp project sync"
+            )
+            raise typer.Exit(1)
+
+        models = read_lock_models(cli_ctx.lockfile_path)
+        model_key = _resolve_model_key(name, agency, dataset)
+        if model_key and model_key in models:
+            print_error(
+                f"Model '{model_key}' already exists in {cli_ctx.lockfile_path}. "
+                "Use 'dbp model sync' to update it."
+            )
+            raise typer.Exit(1)
+
+        _scaffold_model(cli_ctx, name or "dbport_project", template, dataset, agency, path, force)
 
 
 def _resolve_model_key(
-    name: str | None, agency: str | None, dataset: str | None,
+    name: str | None,
+    agency: str | None,
+    dataset: str | None,
 ) -> str | None:
     """Derive a model key from the user's arguments.
 
@@ -107,92 +102,22 @@ def _resolve_model_key(
 
 
 # ---------------------------------------------------------------------------
-# Sync
-# ---------------------------------------------------------------------------
-
-def _do_sync(cli_ctx, model_key: str, model_data: dict) -> None:
-    """Create a DBPort instance for the model, triggering sync in __init__."""
-    from ...adapters.primary.client import DBPort
-
-    paths = resolve_model_paths_from_data(cli_ctx, model_data)
-    with DBPort(
-        agency=paths.agency,
-        dataset_id=paths.dataset_id,
-        lock_path=paths.lock_path,
-        duckdb_path=paths.duckdb_path,
-        model_root=paths.model_root,
-    ):
-        pass  # sync happens in __init__
-
-
-def _sync_single_model(cli_ctx, model_key: str, model_data: dict) -> None:
-    """Sync a single existing model with tree progress display."""
-    with cli_tree_progress(
-        enabled=not cli_ctx.json_output,
-        title="Initializing",
-    ) as model_ctx:
-        with model_ctx(model_key):
-            _do_sync(cli_ctx, model_key, model_data)
-
-    if cli_ctx.json_output:
-        print_json("init", {"synced": [model_key], "total": 1})
-    else:
-        print_success(f"Synced {model_key}")
-
-
-def _sync_all_models(cli_ctx, models: dict) -> None:
-    """Sync all models in the lock file, running in parallel with tree progress."""
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    if not models:
-        print_error(
-            f"No models found in {cli_ctx.lockfile_path}. "
-            "Run 'dbp init <name>' to create a model first."
-        )
-        raise typer.Exit(1)
-
-    synced: list[str] = []
-    failed: list[str] = []
-
-    with cli_tree_progress(
-        enabled=not cli_ctx.json_output,
-        title="Initializing models",
-    ) as model_ctx:
-        def _sync_worker(model_key: str, model_data: dict) -> str:
-            with model_ctx(model_key):
-                _do_sync(cli_ctx, model_key, model_data)
-            return model_key
-
-        with ThreadPoolExecutor(max_workers=4) as pool:
-            futures = {
-                pool.submit(_sync_worker, key, data): key
-                for key, data in models.items()
-            }
-            for fut in as_completed(futures):
-                key = futures[fut]
-                try:
-                    fut.result()
-                    synced.append(key)
-                except Exception:
-                    failed.append(key)
-
-    if cli_ctx.json_output:
-        print_json("init", {"synced": synced, "total": len(models)})
-    else:
-        print_success(f"Synced {len(synced)}/{len(models)} model(s)")
-
-
-# ---------------------------------------------------------------------------
 # Scaffold
 # ---------------------------------------------------------------------------
 
+
 def _scaffold_model(
-    cli_ctx, name: str, template: str, dataset: str | None,
-    agency: str | None, path: str | None, force: bool,
+    cli_ctx,
+    name: str,
+    template: str,
+    dataset: str | None,
+    agency: str | None,
+    path: str | None,
+    force: bool,
 ) -> None:
     """Create a new model scaffold and register in the lock file."""
-    from ..context import read_models_folder
     from ...infrastructure.progress import progress_callback
+    from ..context import read_models_folder
 
     project_name = name
 
@@ -226,8 +151,7 @@ def _scaffold_model(
         existing = list(target.iterdir()) if target.is_dir() else [target]
         if existing:
             print_error(
-                f"Directory '{target}' already exists and is not empty. "
-                "Use --force to overwrite."
+                f"Directory '{target}' already exists and is not empty. Use --force to overwrite."
             )
             raise typer.Exit(1)
 
@@ -255,10 +179,9 @@ def _scaffold_model(
         if not main_sql.exists() or force:
             main_sql.write_text(_MAIN_SQL_TEMPLATE.format(**fmt), encoding="utf-8")
 
-        if template in ("python", "hybrid"):
-            run_py = target / "run.py"
-            if not run_py.exists() or force:
-                run_py.write_text(_RUN_PY_TEMPLATE.format(**fmt), encoding="utf-8")
+        main_py = target / "main.py"
+        if not main_py.exists() or force:
+            main_py.write_text(_MAIN_PY_TEMPLATE.format(**fmt), encoding="utf-8")
 
         if cb:
             cb.finished()
@@ -279,15 +202,12 @@ def _scaffold_model(
 
         _register_model(lock_path, _agency, _dataset, model_root_rel, duckdb_rel)
 
-        # Set run_hook based on template
-        if template in ("python", "hybrid"):
-            run_hook = "run.py"
-        else:
-            run_hook = "sql/main.sql"
+        run_hook = "main.py"
         _set_run_hook(lock_path, _agency, _dataset, model_root_rel, duckdb_rel, run_hook)
 
         # Always set the newly initialized model as the default
         from ..context import write_default_model
+
         model_key = f"{_agency}.{_dataset}"
         write_default_model(lock_path, model_key)
 
@@ -295,15 +215,18 @@ def _scaffold_model(
             cb.finished()
 
     if cli_ctx.json_output:
-        print_json("init", {
-            "name": project_name,
-            "path": str(target),
-            "agency": _agency,
-            "dataset": _dataset,
-            "template": template,
-            "model_root": model_root_rel,
-            "run_hook": run_hook,
-        })
+        print_json(
+            "init",
+            {
+                "name": project_name,
+                "path": str(target),
+                "agency": _agency,
+                "dataset": _dataset,
+                "template": template,
+                "model_root": model_root_rel,
+                "run_hook": run_hook,
+            },
+        )
     else:
         print_success(f"Created model '{project_name}' at {target}")
         print_info(f"  Agency:     {_agency}")
@@ -315,7 +238,7 @@ def _scaffold_model(
         print_info("")
         print_info("Next steps:")
         print_info(f"  cd {model_root_rel}")
-        print_info("  dbp schema sql/create_output.sql")
+        print_info(f"  dbp config model {model_key} schema sql/create_output.sql")
         print_info("  dbp load <namespace.table>")
         print_info("  dbp run --version YYYY-MM-DD")
 
@@ -324,9 +247,13 @@ def _scaffold_model(
 # Lock helpers
 # ---------------------------------------------------------------------------
 
+
 def _register_model(
-    lock_path: Path, agency: str, dataset_id: str,
-    model_root: str, duckdb_path: str,
+    lock_path: Path,
+    agency: str,
+    dataset_id: str,
+    model_root: str,
+    duckdb_path: str,
 ) -> None:
     """Add a model entry to the repo-root dbport.lock."""
     from ...adapters.secondary.lock.toml import TomlLockAdapter
@@ -345,8 +272,12 @@ def _register_model(
 
 
 def _set_run_hook(
-    lock_path: Path, agency: str, dataset_id: str,
-    model_root: str, duckdb_path: str, hook: str,
+    lock_path: Path,
+    agency: str,
+    dataset_id: str,
+    model_root: str,
+    duckdb_path: str,
+    hook: str,
 ) -> None:
     """Set the run_hook for a model in the lock file."""
     from ...adapters.secondary.lock.toml import TomlLockAdapter

--- a/src/dbport/cli/commands/lifecycle.py
+++ b/src/dbport/cli/commands/lifecycle.py
@@ -1,0 +1,248 @@
+"""Shared lifecycle helpers for model and project CLI commands."""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+
+from ..context import read_lock_versions, resolve_model_paths_from_data
+
+
+@contextmanager
+def _phase(key: str, *, title: str, icon: str):
+    from ...infrastructure.progress import progress_phase
+
+    with progress_phase(key, title=title, icon=icon):
+        yield
+
+
+def _run_execute_step(port, target: str) -> None:
+    from ...application.services.run import execute_hook
+    from ...infrastructure.progress import progress_callback
+
+    callback = progress_callback.get(None)
+    if callback is not None:
+        callback.started(f"Executing {target}")
+    try:
+        execute_hook(port, target)
+    except Exception:
+        failed = getattr(callback, "failed", None)
+        if callable(failed):
+            failed(f"Failed executing {target}")
+        raise
+    if callback is not None:
+        callback.finished(f"Executed {target}")
+
+
+def resolve_publish_version(cli_ctx, model_key: str, explicit_version: str | None) -> str:
+    """Resolve the publish version for a model.
+
+    Priority: explicit CLI flag, configured version in lock, latest completed
+    version in lock.
+    """
+    from ..context import read_lock_version_config
+
+    if explicit_version is not None:
+        return explicit_version
+
+    configured = read_lock_version_config(cli_ctx.lockfile_path, model_key)
+    if configured is not None:
+        return configured
+
+    lock_versions = read_lock_versions(cli_ctx.lockfile_path, model_key)
+    completed = [item for item in lock_versions if item.get("completed")]
+    if completed:
+        return completed[-1]["version"]
+
+    raise RuntimeError(
+        f"No version available. Set one with: dbp config model {model_key} version <version>"
+    )
+
+
+def resolve_publish_version_for_publish(
+    cli_ctx,
+    model_key: str,
+    explicit_version: str | None,
+) -> str:
+    """Resolve the publish version for publish-only commands."""
+    if explicit_version is not None:
+        return explicit_version
+
+    lock_versions = read_lock_versions(cli_ctx.lockfile_path, model_key)
+    completed = [item for item in lock_versions if item.get("completed")]
+    if completed:
+        return completed[-1]["version"]
+
+    raise RuntimeError("No completed versions found in lock file. Specify --version explicitly.")
+
+
+def resolve_publish_mode(*, dry_run: bool, refresh: bool) -> str | None:
+    """Map CLI publish flags to the DBPort publish mode."""
+    if dry_run:
+        return "dry"
+    if refresh:
+        return "refresh"
+    return None
+
+
+def sync_model(cli_ctx, model_data: dict) -> dict:
+    """Sync one model by opening DBPort, which runs sync in __init__."""
+    from ...adapters.primary.client import DBPort
+
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
+    with DBPort(
+        agency=paths.agency,
+        dataset_id=paths.dataset_id,
+        lock_path=paths.lock_path,
+        duckdb_path=paths.duckdb_path,
+        model_root=paths.model_root,
+        load_inputs_on_init=False,
+    ):
+        pass
+
+    return {
+        "agency": paths.agency,
+        "dataset_id": paths.dataset_id,
+    }
+
+
+def load_model(
+    cli_ctx,
+    model_key: str,
+    model_data: dict,
+    *,
+    update: bool = False,
+) -> dict:
+    """Load configured inputs for one model."""
+    from ...adapters.primary.client import DBPort
+
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
+    inputs = model_data.get("inputs", [])
+    loaded: list[str] = []
+
+    if not inputs:
+        return {
+            "model": model_key,
+            "loaded": loaded,
+            "updated": update,
+        }
+
+    with DBPort(
+        agency=paths.agency,
+        dataset_id=paths.dataset_id,
+        lock_path=paths.lock_path,
+        duckdb_path=paths.duckdb_path,
+        model_root=paths.model_root,
+        load_inputs_on_init=False,
+    ) as port:
+        with _phase("load", title="Load", icon="📥"):
+            for item in inputs:
+                port.load(
+                    item["table_address"],
+                    filters=item.get("filters"),
+                    version=None if update else item.get("version"),
+                )
+                loaded.append(item["table_address"])
+
+    return {
+        "model": model_key,
+        "loaded": loaded,
+        "updated": update,
+    }
+
+
+def exec_model(cli_ctx, model_key: str, model_data: dict, *, target: str | None = None) -> dict:
+    """Execute a model hook or an explicit override target."""
+    from ...adapters.primary.client import DBPort
+
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
+    started = time.monotonic()
+
+    with DBPort(
+        agency=paths.agency,
+        dataset_id=paths.dataset_id,
+        lock_path=paths.lock_path,
+        duckdb_path=paths.duckdb_path,
+        model_root=paths.model_root,
+    ) as port:
+        effective_target = target or port.run_hook
+        _run_execute_step(port, effective_target)
+
+    return {
+        "model": model_key,
+        "target": effective_target,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }
+
+
+def publish_model(
+    cli_ctx,
+    model_key: str,
+    model_data: dict,
+    *,
+    version: str | None = None,
+    dry_run: bool = False,
+    refresh: bool = False,
+) -> dict:
+    """Publish one model."""
+    from ...adapters.primary.client import DBPort
+
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
+    pub_version = resolve_publish_version_for_publish(cli_ctx, model_key, version)
+    mode = resolve_publish_mode(dry_run=dry_run, refresh=refresh)
+
+    with DBPort(
+        agency=paths.agency,
+        dataset_id=paths.dataset_id,
+        lock_path=paths.lock_path,
+        duckdb_path=paths.duckdb_path,
+        model_root=paths.model_root,
+    ) as port:
+        with _phase("publish", title="Publish", icon="🚀"):
+            port.publish(version=pub_version, mode=mode)
+
+    return {
+        "model": model_key,
+        "version": pub_version,
+        "mode": mode,
+    }
+
+
+def run_model(
+    cli_ctx,
+    model_key: str,
+    model_data: dict,
+    *,
+    version: str | None = None,
+    target: str | None = None,
+    dry_run: bool = False,
+    refresh: bool = False,
+) -> dict:
+    """Run sync, execute hook, and publish for one model."""
+    from ...adapters.primary.client import DBPort
+
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
+    pub_version = resolve_publish_version(cli_ctx, model_key, version)
+    mode = resolve_publish_mode(dry_run=dry_run, refresh=refresh)
+    started = time.monotonic()
+
+    with DBPort(
+        agency=paths.agency,
+        dataset_id=paths.dataset_id,
+        lock_path=paths.lock_path,
+        duckdb_path=paths.duckdb_path,
+        model_root=paths.model_root,
+    ) as port:
+        effective_target = target or port.run_hook
+        with _phase("exec", title="Exec", icon="⚙️"):
+            _run_execute_step(port, effective_target)
+        with _phase("publish", title="Publish", icon="🚀"):
+            port.publish(version=pub_version, mode=mode)
+
+    return {
+        "model": model_key,
+        "target": effective_target,
+        "version": pub_version,
+        "mode": mode,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }

--- a/src/dbport/cli/commands/model.py
+++ b/src/dbport/cli/commands/model.py
@@ -1,0 +1,196 @@
+"""dbp model — run lifecycle commands for one model."""
+
+from __future__ import annotations
+
+import typer
+
+from ..context import resolve_model_key
+from ..errors import cli_error_handler
+from ..render import cli_progress, cli_tree_progress, print_info, print_json, print_success
+from . import lifecycle
+
+model_app = typer.Typer(
+    name="model",
+    help="Run lifecycle operations for one model.",
+    no_args_is_help=True,
+)
+
+
+@model_app.command("sync")
+def model_sync_cmd(
+    ctx: typer.Context,
+    model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
+) -> None:
+    """Sync one model, defaulting to the resolved default model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("model sync", json_output=cli_ctx.json_output):
+        model_key, model_data = resolve_model_key(cli_ctx, model)
+        with cli_tree_progress(
+            enabled=not cli_ctx.json_output and not cli_ctx.quiet,
+            title=f"Syncing {model_key}",
+        ) as model_ctx:
+            with model_ctx(model_key):
+                lifecycle.sync_model(cli_ctx, model_data)
+
+        if cli_ctx.json_output:
+            print_json("model sync", {"synced": [model_key], "total": 1, "model": model_key})
+        else:
+            print_success(f"Synced {model_key}")
+
+
+@model_app.command("load")
+def model_load_cmd(
+    ctx: typer.Context,
+    model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
+    update: bool = typer.Option(
+        False,
+        "--update",
+        help="Resolve the newest available snapshot for each configured input.",
+    ),
+) -> None:
+    """Load configured inputs for one model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("model load", json_output=cli_ctx.json_output):
+        model_key, model_data = resolve_model_key(cli_ctx, model)
+        with cli_tree_progress(
+            enabled=not cli_ctx.json_output and not cli_ctx.quiet,
+            title=f"Loading {model_key}",
+        ) as model_ctx:
+            with model_ctx(model_key):
+                result = lifecycle.load_model(
+                    cli_ctx,
+                    model_key,
+                    model_data,
+                    update=update,
+                )
+
+        if cli_ctx.json_output:
+            print_json("model load", result)
+        else:
+            if result["loaded"]:
+                action = "Updated" if update else "Loaded"
+                print_success(f"{action} {len(result['loaded'])} input(s) for {model_key}")
+            else:
+                print_info(f"No inputs configured for {model_key}")
+
+
+@model_app.command("exec")
+def model_exec_cmd(
+    ctx: typer.Context,
+    model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
+    target: str | None = typer.Option(
+        None,
+        "--target",
+        help="Execute this .sql or .py file instead of the configured model hook.",
+    ),
+    timing: bool = typer.Option(False, "--timing", help="Print execution duration."),
+) -> None:
+    """Execute the configured model hook or an explicit override target."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("model exec", json_output=cli_ctx.json_output):
+        model_key, model_data = resolve_model_key(cli_ctx, model)
+        with cli_progress(enabled=not cli_ctx.json_output and not cli_ctx.quiet):
+            result = lifecycle.exec_model(cli_ctx, model_key, model_data, target=target)
+
+        if cli_ctx.json_output:
+            print_json("model exec", result)
+        else:
+            print_success(f"Executed {result['target']}")
+            print_info(f"  Model: {model_key}")
+            if timing:
+                print_info(f"  Duration: {result['elapsed_seconds']:.2f}s")
+
+
+@model_app.command("publish")
+def model_publish_cmd(
+    ctx: typer.Context,
+    model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
+    version: str | None = typer.Option(
+        None, "--version", help="Version identifier for this publish."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate only; do not write data."),
+    refresh: bool = typer.Option(False, "--refresh", help="Overwrite existing version."),
+    message: str | None = typer.Option(None, "--message", "-m", help="Publish note for history."),
+) -> None:
+    """Publish one model, defaulting to the resolved default model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("model publish", json_output=cli_ctx.json_output):
+        model_key, model_data = resolve_model_key(cli_ctx, model)
+        with cli_tree_progress(
+            enabled=not cli_ctx.json_output and not cli_ctx.quiet,
+            title=f"Publishing {model_key}",
+        ) as model_ctx:
+            with model_ctx(model_key):
+                result = lifecycle.publish_model(
+                    cli_ctx,
+                    model_key,
+                    model_data,
+                    version=version,
+                    dry_run=dry_run,
+                    refresh=refresh,
+                )
+
+        if cli_ctx.json_output:
+            print_json("model publish", result)
+        else:
+            if result["mode"] == "dry":
+                print_success(f"Dry run completed for version {result['version']}")
+            else:
+                print_success(f"Published version {result['version']}")
+            print_info(f"  Model: {model_key}")
+            if message:
+                print_info(f"  Note:  {message}")
+
+
+@model_app.command("run")
+def model_run_cmd(
+    ctx: typer.Context,
+    model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
+    version: str | None = typer.Option(
+        None, "--version", help="Version to publish after execution."
+    ),
+    target: str | None = typer.Option(
+        None,
+        "--target",
+        help="Execute this .sql or .py file instead of the configured model hook.",
+    ),
+    timing: bool = typer.Option(False, "--timing", help="Print execution duration."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate only; do not publish."),
+    refresh: bool = typer.Option(False, "--refresh", help="Overwrite existing version."),
+) -> None:
+    """Run sync, hook execution, and publish for one model."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("model run", json_output=cli_ctx.json_output):
+        model_key, model_data = resolve_model_key(cli_ctx, model)
+        with cli_tree_progress(
+            enabled=not cli_ctx.json_output and not cli_ctx.quiet,
+            title=f"Running {model_key}",
+        ) as model_ctx:
+            with model_ctx(model_key):
+                result = lifecycle.run_model(
+                    cli_ctx,
+                    model_key,
+                    model_data,
+                    version=version,
+                    target=target,
+                    dry_run=dry_run,
+                    refresh=refresh,
+                )
+
+        if cli_ctx.json_output:
+            print_json("model run", result)
+        else:
+            print_success(f"Executed model {model_key} via {result['target']}")
+            print_info(f"  Published version: {result['version']}")
+            if timing:
+                print_info(f"  Duration: {result['elapsed_seconds']:.2f}s")

--- a/src/dbport/cli/commands/project.py
+++ b/src/dbport/cli/commands/project.py
@@ -1,0 +1,279 @@
+"""dbp project — run lifecycle commands across all models."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import typer
+
+from ..context import read_lock_models
+from ..errors import cli_error_handler
+from ..render import cli_tree_progress, print_error, print_info, print_json, print_success
+from . import lifecycle
+
+project_app = typer.Typer(
+    name="project",
+    help="Run lifecycle operations across all models in the project.",
+    no_args_is_help=True,
+)
+
+
+def _project_models(cli_ctx) -> dict:
+    models = read_lock_models(cli_ctx.lockfile_path)
+    if not models:
+        raise RuntimeError(
+            f"No models found in {cli_ctx.lockfile_path}. Run 'dbp init <name>' to create a model first."
+        )
+    return models
+
+
+def _project_batches(models: dict) -> list[list[tuple[int, str, dict]]]:
+    indexed_models = list(enumerate(models.items()))
+    model_keys = set(models)
+    dependencies: dict[str, set[str]] = {}
+    dependents: dict[str, set[str]] = defaultdict(set)
+
+    for model_key, model_data in models.items():
+        internal_inputs = {
+            item.get("table_address")
+            for item in model_data.get("inputs", [])
+            if item.get("table_address") in model_keys and item.get("table_address") != model_key
+        }
+        dependencies[model_key] = internal_inputs
+        for dependency in internal_inputs:
+            dependents[dependency].add(model_key)
+
+    available = [model_key for _, (model_key, _) in indexed_models if not dependencies[model_key]]
+    processed: set[str] = set()
+    batches: list[list[tuple[int, str, dict]]] = []
+
+    while available:
+        batch = [
+            (index, model_key, model_data)
+            for index, (model_key, model_data) in indexed_models
+            if model_key in available
+        ]
+        batches.append(batch)
+
+        next_available: list[str] = []
+        for _, model_key, _ in batch:
+            processed.add(model_key)
+            for dependent in dependents.get(model_key, set()):
+                dependencies[dependent].discard(model_key)
+                if not dependencies[dependent]:
+                    next_available.append(dependent)
+        available = next_available
+
+    if len(processed) != len(models):
+        unresolved = [key for key in models if key not in processed]
+        raise RuntimeError(
+            "Cyclic model input dependencies found in dbport.lock: " + ", ".join(unresolved)
+        )
+
+    return batches
+
+
+def _run_for_all(cli_ctx, *, title: str, action, command_name: str) -> list[dict]:
+    models = _project_models(cli_ctx)
+    results_by_index: dict[int, dict] = {}
+    failures_by_index: dict[int, tuple[str, str]] = {}
+    indexed_models = list(enumerate(models.items()))
+    batches = _project_batches(models)
+
+    with cli_tree_progress(
+        enabled=not cli_ctx.json_output and not cli_ctx.quiet,
+        title=title,
+    ) as model_ctx:
+
+        def _worker(index: int, model_key: str, model_data: dict) -> tuple[int, dict]:
+            with model_ctx(model_key):
+                return index, action(model_key, model_data)
+
+        for batch in batches:
+            max_workers = min(4, len(batch)) or 1
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                futures = {
+                    pool.submit(_worker, index, model_key, model_data): (index, model_key)
+                    for index, model_key, model_data in batch
+                }
+                for future in as_completed(futures):
+                    index, model_key = futures[future]
+                    try:
+                        result_index, result = future.result()
+                        results_by_index[result_index] = result
+                    except Exception as exc:
+                        failures_by_index[index] = (model_key, str(exc))
+
+            if failures_by_index:
+                break
+
+    results = [results_by_index[index] for index, _ in indexed_models if index in results_by_index]
+    failures = [
+        failures_by_index[index] for index, _ in indexed_models if index in failures_by_index
+    ]
+
+    if cli_ctx.json_output:
+        print_json(
+            command_name,
+            {"results": results, "failed": failures, "total": len(models)},
+            ok=not failures,
+        )
+    else:
+        if failures:
+            for model_key, detail in failures:
+                print_error(f"{model_key}: {detail}")
+            raise typer.Exit(1)
+
+    return results
+
+
+@project_app.command("sync")
+def project_sync_cmd(ctx: typer.Context) -> None:
+    """Sync all models in the project."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("project sync", json_output=cli_ctx.json_output):
+        results = _run_for_all(
+            cli_ctx,
+            title="Syncing models",
+            action=lambda _model_key, model_data: lifecycle.sync_model(cli_ctx, model_data),
+            command_name="project sync",
+        )
+        if not cli_ctx.json_output:
+            print_success(f"Synced {len(results)} model(s)")
+
+
+@project_app.command("load")
+def project_load_cmd(
+    ctx: typer.Context,
+    update: bool = typer.Option(
+        False,
+        "--update",
+        help="Resolve the newest available snapshot for each configured input.",
+    ),
+) -> None:
+    """Load configured inputs for all models in the project."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("project load", json_output=cli_ctx.json_output):
+        results = _run_for_all(
+            cli_ctx,
+            title="Loading models",
+            action=lambda model_key, model_data: lifecycle.load_model(
+                cli_ctx,
+                model_key,
+                model_data,
+                update=update,
+            ),
+            command_name="project load",
+        )
+        if not cli_ctx.json_output:
+            loaded_models = sum(1 for item in results if item["loaded"])
+            action = "Updated" if update else "Loaded"
+            print_success(f"{action} inputs for {loaded_models} model(s)")
+
+
+@project_app.command("exec")
+def project_exec_cmd(
+    ctx: typer.Context,
+    target: str | None = typer.Option(
+        None,
+        "--target",
+        help="Execute this .sql or .py file instead of each model's configured hook.",
+    ),
+) -> None:
+    """Execute the configured hook, or an override target, for all models."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("project exec", json_output=cli_ctx.json_output):
+        results = _run_for_all(
+            cli_ctx,
+            title="Executing models",
+            action=lambda model_key, model_data: lifecycle.exec_model(
+                cli_ctx,
+                model_key,
+                model_data,
+                target=target,
+            ),
+            command_name="project exec",
+        )
+        if not cli_ctx.json_output:
+            print_success(f"Executed {len(results)} model(s)")
+
+
+@project_app.command("publish")
+def project_publish_cmd(
+    ctx: typer.Context,
+    version: str | None = typer.Option(
+        None, "--version", help="Version identifier for this publish."
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate only; do not write data."),
+    refresh: bool = typer.Option(False, "--refresh", help="Overwrite existing version."),
+    message: str | None = typer.Option(None, "--message", "-m", help="Publish note for history."),
+) -> None:
+    """Publish all models in the project."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("project publish", json_output=cli_ctx.json_output):
+        results = _run_for_all(
+            cli_ctx,
+            title="Publishing models",
+            action=lambda model_key, model_data: lifecycle.publish_model(
+                cli_ctx,
+                model_key,
+                model_data,
+                version=version,
+                dry_run=dry_run,
+                refresh=refresh,
+            ),
+            command_name="project publish",
+        )
+        if not cli_ctx.json_output:
+            if results and results[0]["mode"] == "dry":
+                print_success(f"Dry run completed for {len(results)} model(s)")
+            else:
+                print_success(f"Published {len(results)} model(s)")
+            if message:
+                print_info(f"  Note:  {message}")
+
+
+@project_app.command("run")
+def project_run_cmd(
+    ctx: typer.Context,
+    version: str | None = typer.Option(
+        None, "--version", help="Version to publish after execution."
+    ),
+    target: str | None = typer.Option(
+        None,
+        "--target",
+        help="Execute this .sql or .py file instead of each model's configured hook.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate only; do not publish."),
+    refresh: bool = typer.Option(False, "--refresh", help="Overwrite existing version."),
+) -> None:
+    """Run sync, hook execution, and publish for all models."""
+    from ..main import get_cli_ctx
+
+    cli_ctx = get_cli_ctx(ctx)
+    with cli_error_handler("project run", json_output=cli_ctx.json_output):
+        results = _run_for_all(
+            cli_ctx,
+            title="Running models",
+            action=lambda model_key, model_data: lifecycle.run_model(
+                cli_ctx,
+                model_key,
+                model_data,
+                version=version,
+                target=target,
+                dry_run=dry_run,
+                refresh=refresh,
+            ),
+            command_name="project run",
+        )
+        if not cli_ctx.json_output:
+            print_success(f"Ran {len(results)} model(s)")

--- a/src/dbport/cli/commands/run.py
+++ b/src/dbport/cli/commands/run.py
@@ -19,7 +19,9 @@ from ..render import cli_tree_progress, print_info, print_json, print_success
 def run_cmd(
     ctx: typer.Context,
     model: str | None = typer.Argument(None, help="Model key (agency.dataset_id)."),
-    version: str | None = typer.Option(None, "--version", help="Version to publish after execution."),
+    version: str | None = typer.Option(
+        None, "--version", help="Version to publish after execution."
+    ),
     timing: bool = typer.Option(False, "--timing", help="Print execution duration."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Validate only; do not publish."),
     refresh: bool = typer.Option(False, "--refresh", help="Overwrite existing version."),
@@ -56,20 +58,16 @@ def run_cmd(
                     # Resolve version: CLI flag → config → latest completed → fail
                     pub_version = version
                     if pub_version is None:
-                        pub_version = read_lock_version_config(
-                            cli_ctx.lockfile_path, model_key
-                        )
+                        pub_version = read_lock_version_config(cli_ctx.lockfile_path, model_key)
                     if pub_version is None:
-                        lock_versions = read_lock_versions(
-                            cli_ctx.lockfile_path, model_key
-                        )
+                        lock_versions = read_lock_versions(cli_ctx.lockfile_path, model_key)
                         completed = [v for v in lock_versions if v.get("completed")]
                         if completed:
                             pub_version = completed[-1]["version"]
                     if pub_version is None:
                         raise typer.BadParameter(
                             "No version available. Set one with: "
-                            "dbp config version <version>"
+                            f"dbp config model {model_key} version <version>"
                         )
 
                     mode = None

--- a/src/dbport/cli/commands/schema.py
+++ b/src/dbport/cli/commands/schema.py
@@ -1,10 +1,10 @@
-"""dbp schema — show or apply the output schema."""
+"""dbp config model <model> schema — show or apply the output schema."""
 
 from __future__ import annotations
 
 import typer
 
-from ..context import resolve_model_paths
+from ..context import read_lock_models, resolve_model_paths, resolve_model_paths_from_data
 from ..errors import cli_error_handler
 from ..render import print_info, print_json, print_success, print_table, print_warning
 
@@ -18,41 +18,82 @@ def schema_cmd(
     from ..main import get_cli_ctx
 
     cli_ctx = get_cli_ctx(ctx)
+    command_name = "config model schema"
 
-    with cli_error_handler("schema", json_output=cli_ctx.json_output):
+    with cli_error_handler(command_name, json_output=cli_ctx.json_output):
         if source is not None:
-            _apply_schema(cli_ctx, source)
+            _apply_schema(ctx, cli_ctx, source)
         else:
-            _show_schema(cli_ctx)
+            _show_schema(ctx, cli_ctx)
 
 
-def _show_schema(cli_ctx) -> None:
-    """Display the current schema from the lock file."""
-    from ..context import _resolve_model_data, read_lock_models
+def _selected_model_key(ctx: typer.Context) -> str | None:
+    current = ctx
+    while current is not None:
+        if current.obj and "config_model_key" in current.obj:
+            return current.obj["config_model_key"]
+        current = current.parent
+    return None
+
+
+def _resolve_schema_target(ctx: typer.Context, cli_ctx) -> tuple[str, dict]:
+    """Resolve the model key and data for schema commands.
+
+    When invoked via ``dbp config model <model_key> schema``, prefer the explicit
+    model key from the Typer context. Otherwise, fall back to standard CLI model
+    resolution.
+    """
+    from ..context import _resolve_model_data
 
     models = read_lock_models(cli_ctx.lockfile_path)
     if not models:
-        if cli_ctx.json_output:
-            print_json("schema", {"schema": None})
-        else:
-            print_warning("No models found in dbport.lock.")
-        return
+        raise RuntimeError(
+            f"No models found in {cli_ctx.lockfile_path}. Run 'dbp init' to create a project first."
+        )
+
+    explicit_model_key = _selected_model_key(ctx)
+    if explicit_model_key is not None:
+        if explicit_model_key not in models:
+            raise RuntimeError(
+                f"Model '{explicit_model_key}' not found in {cli_ctx.lockfile_path}. "
+                f"Available: {list(models.keys())}"
+            )
+        return explicit_model_key, models[explicit_model_key]
 
     model_data = _resolve_model_data(cli_ctx, models)
     model_key = f"{model_data.get('agency', '?')}.{model_data.get('dataset_id', '?')}"
+    return model_key, model_data
+
+
+def _show_schema(ctx: typer.Context, cli_ctx) -> None:
+    """Display the current schema from the lock file."""
+    try:
+        model_key, model_data = _resolve_schema_target(ctx, cli_ctx)
+    except RuntimeError as exc:
+        if cli_ctx.json_output:
+            print_json("config model schema", {"schema": None, "error": str(exc)}, ok=False)
+        else:
+            print_warning(str(exc))
+        return
+
     schema = model_data.get("schema", {})
 
     if cli_ctx.json_output:
-        print_json("schema", {
-            "model": model_key,
-            "ddl": schema.get("ddl"),
-            "columns": schema.get("columns", []),
-        })
+        print_json(
+            "config model schema",
+            {
+                "model": model_key,
+                "ddl": schema.get("ddl"),
+                "columns": schema.get("columns", []),
+            },
+        )
         return
 
     if not schema.get("ddl"):
         print_warning(f"No schema defined for {model_key}.")
-        print_info("Apply a schema with: dbp schema sql/create_output.sql")
+        print_info(
+            f"Apply a schema with: dbp config model {model_key} schema sql/create_output.sql"
+        )
         return
 
     print_info(f"[bold]Schema for {model_key}[/]")
@@ -62,12 +103,14 @@ def _show_schema(cli_ctx) -> None:
     if columns:
         rows = []
         for col in columns:
-            rows.append([
-                str(col.get("column_pos", "")),
-                col.get("column_name", "?"),
-                col.get("sql_type", "?"),
-                col.get("codelist_id", ""),
-            ])
+            rows.append(
+                [
+                    str(col.get("column_pos", "")),
+                    col.get("column_name", "?"),
+                    col.get("sql_type", "?"),
+                    col.get("codelist_id", ""),
+                ]
+            )
         print_table("Columns", ["Pos", "Name", "Type", "Codelist"], rows)
     else:
         print_info("[dim]No columns defined.[/]")
@@ -77,13 +120,14 @@ def _show_schema(cli_ctx) -> None:
     print_info(schema["ddl"])
 
 
-def _apply_schema(cli_ctx, source: str) -> None:
+def _apply_schema(ctx: typer.Context, cli_ctx, source: str) -> None:
     """Apply a schema from a SQL file via DBPort client."""
     from pathlib import Path
 
     from ...adapters.primary.client import DBPort
 
-    paths = resolve_model_paths(cli_ctx)
+    _, model_data = _resolve_schema_target(ctx, cli_ctx)
+    paths = resolve_model_paths_from_data(cli_ctx, model_data)
 
     # Pre-check: resolve the source path against model_root
     if source.strip().lower().endswith(".sql"):
@@ -103,6 +147,9 @@ def _apply_schema(cli_ctx, source: str) -> None:
         port.schema(source)
 
     if cli_ctx.json_output:
-        print_json("schema", {"applied": source, "model": f"{paths.agency}.{paths.dataset_id}"})
+        print_json(
+            "config model schema",
+            {"applied": source, "model": f"{paths.agency}.{paths.dataset_id}"},
+        )
     else:
         print_success(f"Schema applied from {source}")

--- a/src/dbport/cli/commands/status.py
+++ b/src/dbport/cli/commands/status.py
@@ -1,4 +1,4 @@
-"""dbp status — show resolved project and runtime state."""
+"""dbp status — show resolved project state and related diagnostics."""
 
 from __future__ import annotations
 
@@ -8,12 +8,24 @@ from ..context import read_lock_models
 from ..errors import cli_error_handler
 from ..render import print_info, print_json, print_table, print_warning
 
+status_app = typer.Typer(
+    name="status",
+    help="Show resolved project and runtime state.",
+    no_args_is_help=False,
+)
 
+
+@status_app.callback(invoke_without_command=True)
 def status_cmd(
     ctx: typer.Context,
-    show_history: bool = typer.Option(False, "--show-history", help="Show version publish history."),
+    show_history: bool = typer.Option(
+        False, "--show-history", help="Show version publish history."
+    ),
 ) -> None:
     """Show resolved project and runtime state."""
+    if ctx.invoked_subcommand is not None:
+        return
+
     from ..main import get_cli_ctx
 
     cli_ctx = get_cli_ctx(ctx)
@@ -34,12 +46,8 @@ def status_cmd(
                     "dataset_id": m.get("dataset_id"),
                     "model_root": m.get("model_root"),
                     "schema_defined": bool(m.get("schema", {}).get("ddl")),
-                    "inputs": [
-                        inp.get("table_address") for inp in m.get("inputs", [])
-                    ],
-                    "versions": [
-                        v.get("version") for v in m.get("versions", [])
-                    ],
+                    "inputs": [inp.get("table_address") for inp in m.get("inputs", [])],
+                    "versions": [v.get("version") for v in m.get("versions", [])],
                 }
                 data["models"][key] = model_data
             print_json("status", data)
@@ -89,7 +97,9 @@ def status_cmd(
             versions = m.get("versions", [])
             if versions:
                 latest = versions[-1]
-                print_info(f"  Published:  {len(versions)} version(s), latest: {latest.get('version', '?')}")
+                print_info(
+                    f"  Published:  {len(versions)} version(s), latest: {latest.get('version', '?')}"
+                )
             else:
                 print_info("  Published:  [dim]none[/]")
 
@@ -98,14 +108,21 @@ def status_cmd(
                 print_info("")
                 rows = []
                 for v in versions:
-                    rows.append([
-                        v.get("version", "?"),
-                        str(v.get("published_at", "?")),
-                        str(v.get("rows", "?")),
-                        "yes" if v.get("completed") else "no",
-                    ])
+                    rows.append(
+                        [
+                            v.get("version", "?"),
+                            str(v.get("published_at", "?")),
+                            str(v.get("rows", "?")),
+                            "yes" if v.get("completed") else "no",
+                        ]
+                    )
                 print_table(
                     f"Version History — {key}",
                     ["Version", "Published At", "Rows", "Completed"],
                     rows,
                 )
+
+
+from .check import check_cmd  # noqa: E402
+
+status_app.command("check")(check_cmd)

--- a/src/dbport/cli/main.py
+++ b/src/dbport/cli/main.py
@@ -40,7 +40,10 @@ def _version_callback(value: bool) -> None:
 def main_callback(
     ctx: typer.Context,
     version: bool = typer.Option(
-        False, "--version", callback=_version_callback, is_eager=True,
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
         help="Show version and exit.",
     ),
     project: str | None = ProjectOption,
@@ -73,14 +76,10 @@ def get_cli_ctx(ctx: typer.Context) -> CliContext:
 
 # -- Register commands --------------------------------------------------------
 
-from .commands import check, config, execute, init, load, publish, run, schema, status  # noqa: E402
+from .commands import config, init, model, project, status  # noqa: E402
 
 app.command(name="init")(init.init_cmd)
-app.command(name="status")(status.status_cmd)
-app.command(name="check")(check.check_cmd)
-app.command(name="schema")(schema.schema_cmd)
-app.command(name="load")(load.load_cmd)
-app.command(name="execute")(execute.execute_cmd)
-app.command(name="run")(run.run_cmd)
-app.command(name="publish")(publish.publish_cmd)
+app.add_typer(status.status_app, name="status")
+app.add_typer(model.model_app, name="model")
+app.add_typer(project.project_app, name="project")
 app.add_typer(config.config_app, name="config")

--- a/src/dbport/cli/render.py
+++ b/src/dbport/cli/render.py
@@ -47,12 +47,14 @@ def configure_cli_logging(*, verbose: bool, quiet: bool) -> None:
 
 # -- JSON output -------------------------------------------------------------
 
+
 def print_json(command: str, data: Any, *, ok: bool = True) -> None:
     payload = {"ok": ok, "command": command, "data": data}
     sys.stdout.write(json.dumps(payload, indent=2, default=str) + "\n")
 
 
 # -- Human-readable output ---------------------------------------------------
+
 
 def print_success(msg: str) -> None:
     _stdout.print(f"[green bold]OK[/] {msg}")
@@ -175,9 +177,7 @@ class RichProgressAdapter:
             return
         if message:
             self._progress.update(self._task_id, description=message)
-        self._progress.update(
-            self._task_id, total=1, completed=1, failed=True
-        )
+        self._progress.update(self._task_id, total=1, completed=1, failed=True)
         self._task_id = None
 
     def finished(self, message: str | None = None) -> None:
@@ -305,10 +305,7 @@ class _LiveProgressLabel:
                 f"  [dim]{elapsed}{self._eta}[/]"
             )
         else:
-            label = render_markup(
-                f"{self._text}  "
-                f"[dim]{self._completed:,} rows  {elapsed}[/]"
-            )
+            label = render_markup(f"{self._text}  [dim]{self._completed:,} rows  {elapsed}[/]")
         grid = RichTable.grid(padding=(0, 1))
         grid.add_row(self._spinner, label)
         yield grid
@@ -323,38 +320,31 @@ def _fmt_elapsed(seconds: float) -> str:
     return f"{m}:{s:02d}"
 
 
-class ModelNode:
-    """Per-model progress callback that renders steps as children of a Rich Tree branch.
-
-    Thread-safe: all tree mutations are guarded by *lock* and flushed via *live*.
-    """
+class _TreeProgressNode:
+    """Shared tree progress behavior for model and phase branches."""
 
     def __init__(
         self,
+        *,
         branch: Tree,
         root_tree: Tree,
         live: Live,
         lock: threading.Lock,
-        model_key: str,
+        on_fail: Callable[[], None] | None = None,
     ) -> None:
         self._branch = branch
         self._root_tree = root_tree
         self._live = live
         self._lock = lock
-        self._model_key = model_key
+        self._on_fail = on_fail
         self._current_node: Tree | None = None
         self._current_desc: str = ""
         self._step_start: float = 0.0
-        self._model_start: float = _time.monotonic()
-        self._model_failed = False
         self._total: int | None = None
         self._completed: int = 0
 
-    # -- ProgressCallback protocol -------------------------------------------
-
     def started(self, description: str, total: int | None = None) -> None:
         with self._lock:
-            # Auto-finish any previous step
             if self._current_node is not None:
                 self._finish_current_node()
             self._current_desc = description
@@ -410,14 +400,59 @@ class ModelNode:
             if self._current_node is not None:
                 elapsed = _time.monotonic() - self._step_start
                 desc = message or self._current_desc
-                self._current_node.label = (
-                    f"[red bold]✗[/] {desc}  [dim]{_fmt_elapsed(elapsed)}[/]"
-                )
+                self._current_node.label = f"[red bold]✗[/] {desc}  [dim]{_fmt_elapsed(elapsed)}[/]"
                 self._current_node = None
-                self._total = None
-                self._completed = 0
-                self._model_failed = True
-                self._live.update(self._root_tree)
+            self._total = None
+            self._completed = 0
+            if self._on_fail is not None:
+                self._on_fail()
+            self._live.update(self._root_tree)
+
+    def _finish_current_node(self, message: str | None = None) -> None:
+        elapsed = _time.monotonic() - self._step_start
+        desc = message or self._current_desc
+        self._current_node.label = f"[green bold]✓[/] {desc}  [dim]{_fmt_elapsed(elapsed)}[/]"  # type: ignore[union-attr]
+        self._current_node = None
+        self._total = None
+        self._completed = 0
+
+
+class ModelNode(_TreeProgressNode):
+    """Per-model progress callback that renders steps as children of a Rich Tree branch.
+
+    Thread-safe: all tree mutations are guarded by *lock* and flushed via *live*.
+    """
+
+    def __init__(
+        self,
+        branch: Tree,
+        root_tree: Tree,
+        live: Live,
+        lock: threading.Lock,
+        model_key: str,
+    ) -> None:
+        super().__init__(
+            branch=branch, root_tree=root_tree, live=live, lock=lock, on_fail=self._mark_failed
+        )
+        self._model_key = model_key
+        self._model_start: float = _time.monotonic()
+        self._model_failed = False
+        self._phases: dict[str, _PhaseNode] = {}
+        self._phase_order: list[str] = []
+
+    @contextmanager
+    def phase(self, key: str, *, title: str, icon: str):
+        phase = self._ensure_phase(key, title=title, icon=icon)
+        with _model_progress_context(phase):
+            error: Exception | None = None
+            phase.start()
+            try:
+                yield phase
+            except Exception as exc:
+                error = exc
+                raise
+            finally:
+                phase.finish(error)
 
     # -- Model-level finish (called by cli_tree_progress) --------------------
 
@@ -426,39 +461,117 @@ class ModelNode:
             # Auto-finish any dangling step
             if self._current_node is not None:
                 self._finish_current_node()
+            for key in self._phase_order:
+                self._phases[key].finalize()
             elapsed = _time.monotonic() - self._model_start
             if error is not None:
-                self._branch.add(
-                    f"[red bold]✗[/] Failed: {error}"
-                )
+                self._branch.add(f"[red bold]✗[/] Failed: {error}")
                 self._branch.label = (
-                    f"[red bold]✗[/] [bold]{self._model_key}[/]"
-                    f"  [dim]{_fmt_elapsed(elapsed)}[/]"
+                    f"[red bold]✗[/] [bold]{self._model_key}[/]  [dim]{_fmt_elapsed(elapsed)}[/]"
                 )
             elif self._model_failed:
                 self._branch.label = (
-                    f"[red bold]✗[/] [bold]{self._model_key}[/]"
-                    f"  [dim]{_fmt_elapsed(elapsed)}[/]"
+                    f"[red bold]✗[/] [bold]{self._model_key}[/]  [dim]{_fmt_elapsed(elapsed)}[/]"
                 )
             else:
                 self._branch.label = (
-                    f"[green bold]✓[/] [bold]{self._model_key}[/]"
-                    f"  [dim]{_fmt_elapsed(elapsed)}[/]"
+                    f"[green bold]✓[/] [bold]{self._model_key}[/]  [dim]{_fmt_elapsed(elapsed)}[/]"
                 )
             self._live.update(self._root_tree)
 
-    # -- Internal ------------------------------------------------------------
+    def _mark_failed(self) -> None:
+        self._model_failed = True
+
+    def _ensure_phase(self, key: str, *, title: str, icon: str) -> "_PhaseNode":
+        with self._lock:
+            if key in self._phases:
+                return self._phases[key]
+
+            phase_branch = self._branch.add(f"[dim]○[/] {icon} {title}")
+            phase = _PhaseNode(
+                branch=phase_branch,
+                root_tree=self._root_tree,
+                live=self._live,
+                lock=self._lock,
+                title=title,
+                icon=icon,
+                parent=self,
+            )
+            self._phases[key] = phase
+            self._phase_order.append(key)
+            self._live.update(self._root_tree)
+            return phase
+
+
+class _PhaseNode(_TreeProgressNode):
+    """Nested progress callback for one fixed phase under a model branch."""
+
+    def __init__(
+        self,
+        *,
+        branch: Tree,
+        root_tree: Tree,
+        live: Live,
+        lock: threading.Lock,
+        title: str,
+        icon: str,
+        parent: ModelNode,
+    ) -> None:
+        super().__init__(
+            branch=branch,
+            root_tree=root_tree,
+            live=live,
+            lock=lock,
+            on_fail=parent._mark_failed,
+        )
+        self._title = title
+        self._icon = icon
+        self._parent = parent
+        self._phase_start: float | None = None
+        self._failed = False
+        self._finalized = False
+
+    def start(self) -> None:
+        with self._lock:
+            if self._phase_start is None:
+                self._phase_start = _time.monotonic()
+            self._branch.label = _LiveSpinnerLabel(
+                f"{self._icon} {self._title}", start=self._phase_start
+            )
+            self._live.update(self._root_tree)
+
+    def failed(self, message: str | None = None) -> None:
+        self._failed = True
+        super().failed(message)
+
+    def finish(self, error: Exception | None = None) -> None:
+        with self._lock:
+            if self._finalized:
+                return
+            if self._current_node is not None:
+                self._finish_current_node()
+            if self._phase_start is None:
+                self._phase_start = _time.monotonic()
+            elapsed = _time.monotonic() - self._phase_start
+            if error is not None or self._failed:
+                self._branch.label = (
+                    f"[red bold]✗[/] {self._icon} {self._title}  [dim]{_fmt_elapsed(elapsed)}[/]"
+                )
+                self._parent._model_failed = True
+            else:
+                self._branch.label = (
+                    f"[green bold]✓[/] {self._icon} {self._title}  [dim]{_fmt_elapsed(elapsed)}[/]"
+                )
+            self._finalized = True
+            self._live.update(self._root_tree)
+
+    def finalize(self) -> None:
+        if self._finalized:
+            return
+        self.finish(None)
 
     def _finish_current_node(self, message: str | None = None) -> None:
-        """Mark the current step as done (must be called under lock)."""
-        elapsed = _time.monotonic() - self._step_start
-        desc = message or self._current_desc
-        self._current_node.label = (  # type: ignore[union-attr]
-            f"[green bold]✓[/] {desc}  [dim]{_fmt_elapsed(elapsed)}[/]"
-        )
-        self._current_node = None
-        self._total = None
-        self._completed = 0
+        super()._finish_current_node(message)
 
 
 @contextmanager
@@ -492,16 +605,19 @@ def cli_tree_progress(
                     pass  # progress events go to the model branch
     """
     if not enabled:
+
         @contextmanager
         def _noop_ctx(model_key: str):
             yield None
+
         yield _noop_ctx
         return
 
     tree = Tree(f"[bold]{title}[/]")
     lock = threading.Lock()
 
-    with Live(tree, console=_console, refresh_per_second=8, transient=False) as live:
+    with Live(tree, console=_console, refresh_per_second=8, transient=True) as live:
+
         @contextmanager
         def model_context(model_key: str):
             with lock:
@@ -519,3 +635,5 @@ def cli_tree_progress(
                     node.finish_model(error)
 
         yield model_context
+
+    _console.print(tree)

--- a/src/dbport/domain/ports/catalog.py
+++ b/src/dbport/domain/ports/catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from ..entities.input import InputDeclaration
+    from ..entities.input import IngestRecord, InputDeclaration
     from ..entities.version import DatasetVersion, VersionRecord
 
 
@@ -41,6 +41,18 @@ class ICatalog(Protocol):
           list and return its snapshot_id.
         - Table has no DBPort metadata → return (None, None) so the caller falls
           back to ``current_snapshot()``.
+        """
+        ...
+
+    def inspect_input(
+        self,
+        declaration: InputDeclaration,
+    ) -> IngestRecord:
+        """Resolve a configured input against the warehouse.
+
+        Validates that the input table exists, resolves the effective version
+        and snapshot, and returns the row count that should be persisted in
+        ``dbport.lock``.
         """
         ...
 

--- a/src/dbport/infrastructure/progress.py
+++ b/src/dbport/infrastructure/progress.py
@@ -7,6 +7,7 @@ CLI layer sets it; library users and tests leave it as None (no-op).
 from __future__ import annotations
 
 import contextvars
+from contextlib import contextmanager
 from typing import Protocol, runtime_checkable
 
 
@@ -38,3 +39,20 @@ class ProgressCallback(Protocol):
 progress_callback: contextvars.ContextVar[ProgressCallback | None] = contextvars.ContextVar(
     "progress_callback", default=None
 )
+
+
+@contextmanager
+def progress_phase(key: str, title: str, icon: str):
+    """Route nested progress events into a named phase when supported.
+
+    Tree-based CLI progress nodes can expose a ``phase(...)`` context manager.
+    Other callbacks ignore phases and continue as a flat progress stream.
+    """
+    callback = progress_callback.get(None)
+    phase_factory = getattr(callback, "phase", None)
+    if callable(phase_factory):
+        with phase_factory(key, title=title, icon=icon):
+            yield
+        return
+
+    yield

--- a/tests/test_dbport/adapters/primary/test_client.py
+++ b/tests/test_dbport/adapters/primary/test_client.py
@@ -60,11 +60,10 @@ class TestDBPortInit:
                 lock_path=str(lock_path),
                 duckdb_path=str(tmp_path / "dbport.duckdb"),
             ) as client:
-                client.schema(
-                    "CREATE OR REPLACE TABLE inputs.emp (geo VARCHAR, year SMALLINT)"
-                )
+                client.schema("CREATE OR REPLACE TABLE inputs.emp (geo VARCHAR, year SMALLINT)")
         assert lock_path.exists()
         from dbport.adapters.secondary.lock.toml import TomlLockAdapter
+
         lock = TomlLockAdapter(lock_path, model_key="wifor.emp", model_root=".", duckdb_path="")
         schema = lock.read_schema()
         assert schema is not None
@@ -97,8 +96,11 @@ class TestDBPortInit:
                 client_b.schema("CREATE OR REPLACE TABLE inputs.sector (nace VARCHAR)")
 
         from dbport.adapters.secondary.lock.toml import TomlLockAdapter
+
         lock_a = TomlLockAdapter(lock_path, model_key="wifor.emp", model_root=".", duckdb_path="")
-        lock_b = TomlLockAdapter(lock_path, model_key="wifor.sector", model_root=".", duckdb_path="")
+        lock_b = TomlLockAdapter(
+            lock_path, model_key="wifor.sector", model_root=".", duckdb_path=""
+        )
 
         schema_a = lock_a.read_schema()
         schema_b = lock_b.read_schema()
@@ -109,6 +111,7 @@ class TestDBPortInit:
     def test_repo_root_discovery(self, tmp_path: Path):
         """When lock_path is not given, lock is placed at repo root (pyproject.toml location)."""
         from dbport.adapters.primary.client import _find_repo_root
+
         # The project has a pyproject.toml — discovery should find it
         repo_root = _find_repo_root(Path(__file__).parent)
         assert (repo_root / "pyproject.toml").exists()
@@ -173,9 +176,11 @@ class TestDBPortAutoLockPath:
         }
         # Patch _caller_dir to return tmp_path so auto-discovery uses tmp_path
         # and _find_repo_root to return tmp_path
-        with patch.dict(os.environ, creds), \
-             patch("dbport.adapters.primary.client._caller_dir", return_value=tmp_path), \
-             patch("dbport.adapters.primary.client._find_repo_root", return_value=tmp_path):
+        with (
+            patch.dict(os.environ, creds),
+            patch("dbport.adapters.primary.client._caller_dir", return_value=tmp_path),
+            patch("dbport.adapters.primary.client._find_repo_root", return_value=tmp_path),
+        ):
             client = DBPort(
                 agency="wifor",
                 dataset_id="emp",
@@ -194,8 +199,10 @@ class TestDBPortAutoDuckdbPath:
             "ICEBERG_CATALOG_TOKEN": "tok",
             "ICEBERG_WAREHOUSE": "wh",
         }
-        with patch.dict(os.environ, creds), \
-             patch("dbport.adapters.primary.client._caller_dir", return_value=tmp_path):
+        with (
+            patch.dict(os.environ, creds),
+            patch("dbport.adapters.primary.client._caller_dir", return_value=tmp_path),
+        ):
             client = DBPort(
                 agency="wifor",
                 dataset_id="mymodel",
@@ -346,11 +353,45 @@ class TestDBPortRunMethod:
                 lock_path=str(tmp_path / "dbport.lock"),
                 duckdb_path=str(tmp_path / "dbport.duckdb"),
             )
-            # No hook set initially
-            assert client.run_hook is None
+            # Falls back to the default model entrypoint
+            assert client.run_hook == "main.py"
             # Set a hook
             client._lock.write_run_hook("sql/main.sql")
             assert client.run_hook == "sql/main.sql"
+            client.close()
+
+    def test_configure_input_delegates_to_ingest_service(self, tmp_path: Path):
+        creds = {
+            "ICEBERG_REST_URI": "https://catalog.example.com",
+            "ICEBERG_CATALOG_TOKEN": "tok",
+            "ICEBERG_WAREHOUSE": "wh",
+        }
+        expected_record = MagicMock()
+
+        with patch.dict(os.environ, creds):
+            client = DBPort(
+                agency="wifor",
+                dataset_id="emp",
+                lock_path=str(tmp_path / "dbport.lock"),
+                duckdb_path=str(tmp_path / "dbport.duckdb"),
+            )
+            mock_svc = MagicMock()
+            mock_svc.configure.return_value = expected_record
+            with patch(
+                "dbport.application.services.ingest.IngestService",
+                return_value=mock_svc,
+            ):
+                result = client.configure_input(
+                    "wifor.source",
+                    filters={"geo": "DE"},
+                    version="2026-03-14",
+                )
+
+            assert result is expected_record
+            declaration = mock_svc.configure.call_args.args[0]
+            assert declaration.table_address == "wifor.source"
+            assert declaration.filters == {"geo": "DE"}
+            assert declaration.version == "2026-03-14"
             client.close()
 
 
@@ -367,10 +408,12 @@ class TestDBPortAutoSchema:
         if mock_catalog is None:
             mock_catalog = MagicMock()
             mock_catalog.table_exists.return_value = True
-            mock_catalog.load_arrow_schema.return_value = pa.schema([
-                pa.field("geo", pa.string()),
-                pa.field("year", pa.int16()),
-            ])
+            mock_catalog.load_arrow_schema.return_value = pa.schema(
+                [
+                    pa.field("geo", pa.string()),
+                    pa.field("year", pa.int16()),
+                ]
+            )
             mock_catalog.update_table_properties = MagicMock()
             mock_catalog.get_table_property.return_value = None
 
@@ -470,7 +513,7 @@ class TestDBPortAutoSchema:
 
 class TestDBPortSyncLocalState:
     def test_sync_exception_does_not_propagate(self, tmp_path: Path):
-        """_sync_local_state swallows exceptions."""
+        """_sync_output_state swallows exceptions."""
         from dbport.adapters.secondary.compute.duckdb import DuckDBComputeAdapter
         from dbport.adapters.secondary.lock.toml import TomlLockAdapter
         from dbport.domain.entities.dataset import Dataset
@@ -493,8 +536,8 @@ class TestDBPortSyncLocalState:
         )
 
         with patch("dbport.application.services.sync.SyncService") as mock_cls:
-            mock_cls.return_value.execute.side_effect = RuntimeError("sync failed")
-            client._sync_local_state()  # should not raise
+            mock_cls.return_value.sync_output_table.side_effect = RuntimeError("sync failed")
+            client._sync_output_state()  # should not raise
 
         client._compute.close()
 

--- a/tests/test_dbport/adapters/secondary/catalog/test_iceberg.py
+++ b/tests/test_dbport/adapters/secondary/catalog/test_iceberg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pytest
 
 from dbport.adapters.secondary.catalog.iceberg import (
@@ -13,6 +14,7 @@ from dbport.adapters.secondary.catalog.iceberg import (
     _write_column_docs,
     _write_table_properties,
 )
+from dbport.domain.entities.input import InputDeclaration
 from dbport.infrastructure.credentials import WarehouseCreds
 
 
@@ -42,12 +44,14 @@ class TestSqlEscape:
 
 class TestCredentialsEscapedInSql:
     def test_s3_credentials_with_quotes_do_not_break_sql(self):
-        adapter = IcebergCatalogAdapter(_make_creds(
-            s3_endpoint="https://s3.example.com",
-            s3_access_key="key'with'quotes",
-            s3_secret_key="secret'key",
-            s3_region="eu-west-1",
-        ))
+        adapter = IcebergCatalogAdapter(
+            _make_creds(
+                s3_endpoint="https://s3.example.com",
+                s3_access_key="key'with'quotes",
+                s3_secret_key="secret'key",
+                s3_region="eu-west-1",
+            )
+        )
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (0,)
 
@@ -120,11 +124,13 @@ class TestIcebergCatalogAdapterInit:
             "pyiceberg.catalog.load_catalog",
             fake_load_catalog,
         )
-        adapter = IcebergCatalogAdapter(_make_creds(
-            s3_endpoint="https://s3.example.com",
-            s3_access_key="key",
-            s3_secret_key="secret",
-        ))
+        adapter = IcebergCatalogAdapter(
+            _make_creds(
+                s3_endpoint="https://s3.example.com",
+                s3_access_key="key",
+                s3_secret_key="secret",
+            )
+        )
         adapter._get_catalog()
 
         assert captured.get("py-io-impl") == "pyiceberg.io.fsspec.FsspecFileIO"
@@ -164,12 +170,14 @@ class TestEnsureWarehouseAttached:
         compute.ensure_extensions.assert_called_once()
 
     def test_configures_s3_path_style(self):
-        adapter = IcebergCatalogAdapter(_make_creds(
-            s3_endpoint="https://host.example.com/storage/v1/s3",
-            s3_access_key="key",
-            s3_secret_key="secret",
-            s3_region="eu-west-1",
-        ))
+        adapter = IcebergCatalogAdapter(
+            _make_creds(
+                s3_endpoint="https://host.example.com/storage/v1/s3",
+                s3_access_key="key",
+                s3_secret_key="secret",
+                s3_region="eu-west-1",
+            )
+        )
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (0,)
 
@@ -233,6 +241,7 @@ class TestIngestIntoCompute:
 
     def _make_adapter_with_mock_catalog(self):
         import pyarrow as pa
+
         arrow_schema = pa.schema([pa.field("id", pa.int32())])
         arrow_table = pa.table({"id": [1, 2, 3]})
         reader = pa.RecordBatchReader.from_batches(arrow_schema, arrow_table.to_batches())
@@ -281,9 +290,7 @@ class TestIngestIntoCompute:
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (42,)
 
-        result = adapter.ingest_into_compute(
-            InputDeclaration(table_address="estat.foo"), compute
-        )
+        result = adapter.ingest_into_compute(InputDeclaration(table_address="estat.foo"), compute)
         assert result == 42
 
     def test_does_not_use_duckdb_warehouse(self):
@@ -404,9 +411,7 @@ class TestIngestViaArrow:
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (7,)
 
-        result = adapter._ingest_via_arrow(
-            InputDeclaration(table_address="estat.bar"), compute
-        )
+        result = adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         assert result == 7
 
     def test_snapshot_id_passed_to_scan(self, monkeypatch):
@@ -445,36 +450,42 @@ class TestIngestViaArrow:
 class TestIsTransientS3Error:
     """_is_transient_s3_error classifies S3/network errors for retry decisions."""
 
-    @pytest.mark.parametrize("msg", [
-        "An error occurred (InvalidKey) when calling GetObject",
-        "OSError: [Errno 5] An error occurred (InvalidKey)",
-        "NoSuchKey: the specified key does not exist",
-        "InvalidAccessKeyId: the key is invalid",
-        "RequestTimeout: your socket connection timed out",
-        "SlowDown: please reduce your request rate",
-        "ServiceUnavailable: service is unavailable",
-        "InternalError: we encountered an internal error",
-        "Connection reset by peer",
-        "Connection aborted",
-        "Broken pipe",
-        "IOError: failed to read file",
-        "OSError: network unreachable",
-        "HTTP 500 Internal Server Error",
-        "HTTP 502 Bad Gateway",
-        "HTTP 503 Service Unavailable",
-        "HTTP 429 Too Many Requests",
-    ])
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "An error occurred (InvalidKey) when calling GetObject",
+            "OSError: [Errno 5] An error occurred (InvalidKey)",
+            "NoSuchKey: the specified key does not exist",
+            "InvalidAccessKeyId: the key is invalid",
+            "RequestTimeout: your socket connection timed out",
+            "SlowDown: please reduce your request rate",
+            "ServiceUnavailable: service is unavailable",
+            "InternalError: we encountered an internal error",
+            "Connection reset by peer",
+            "Connection aborted",
+            "Broken pipe",
+            "IOError: failed to read file",
+            "OSError: network unreachable",
+            "HTTP 500 Internal Server Error",
+            "HTTP 502 Bad Gateway",
+            "HTTP 503 Service Unavailable",
+            "HTTP 429 Too Many Requests",
+        ],
+    )
     def test_transient_errors_detected(self, msg):
         exc = Exception(msg)
         assert IcebergCatalogAdapter._is_transient_s3_error(exc) is True
 
-    @pytest.mark.parametrize("msg", [
-        "Table not found in catalog",
-        "Invalid table address",
-        "Schema mismatch: expected int got string",
-        "disk full",
-        "Permission denied",
-    ])
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Table not found in catalog",
+            "Invalid table address",
+            "Schema mismatch: expected int got string",
+            "disk full",
+            "Permission denied",
+        ],
+    )
     def test_non_transient_errors_not_matched(self, msg):
         exc = Exception(msg)
         assert IcebergCatalogAdapter._is_transient_s3_error(exc) is False
@@ -503,9 +514,7 @@ class TestIngestRetry:
                         "the GetObject operation: Invalid key: "
                         "data/last_updated=2026-02-10T22%3A00%3A00/file.parquet"
                     )
-                return pa.RecordBatchReader.from_batches(
-                    arrow_schema, arrow_table.to_batches()
-                )
+                return pa.RecordBatchReader.from_batches(arrow_schema, arrow_table.to_batches())
 
             mock_scan.to_arrow_batch_reader = to_reader
             return mock_scan
@@ -529,9 +538,7 @@ class TestIngestRetry:
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (3,)
 
-        result = adapter._ingest_via_arrow(
-            InputDeclaration(table_address="estat.bar"), compute
-        )
+        result = adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         assert result == 3
         assert call_count[0] == 3  # 2 failures + 1 success
 
@@ -543,9 +550,7 @@ class TestIngestRetry:
         compute.execute.return_value.fetchone.return_value = (3,)
 
         with pytest.raises(OSError, match="InvalidKey"):
-            adapter._ingest_via_arrow(
-                InputDeclaration(table_address="estat.bar"), compute
-            )
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         assert call_count[0] == 3  # tried 3 times (max retries)
 
     def test_non_transient_error_not_retried(self):
@@ -572,9 +577,7 @@ class TestIngestRetry:
         compute = MagicMock()
 
         with pytest.raises(RuntimeError, match="disk full"):
-            adapter._ingest_via_arrow(
-                InputDeclaration(table_address="estat.bar"), compute
-            )
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         # Should have been called only once — no retry
         mock_scan.to_arrow_batch_reader.assert_called_once()
 
@@ -591,6 +594,7 @@ class TestResolveInputSnapshot:
         adapter._catalog = mock_catalog
         # Stub get_table_property to read from our mock
         import json
+
         meta = json.loads(metadata_json)
 
         def _get_prop(table_address, key):
@@ -601,10 +605,13 @@ class TestResolveInputSnapshot:
 
     def _meta_json(self, latest: str, versions: list) -> str:
         import json
-        return json.dumps({
-            "last_updated_data_at": latest,
-            "versions": versions,
-        })
+
+        return json.dumps(
+            {
+                "last_updated_data_at": latest,
+                "versions": versions,
+            }
+        )
 
     def test_returns_none_none_for_table_without_dbport_metadata(self):
         adapter = IcebergCatalogAdapter(_make_creds())
@@ -660,6 +667,111 @@ class TestResolveInputSnapshot:
         adapter.get_table_property = lambda addr, key: "not valid json{"
         result = adapter.resolve_input_snapshot("wifor.foo", None)
         assert result == (None, None)
+
+
+class TestInspectInput:
+    def _make_table(self, *, metadata_json: str | None = None):
+        mock_table = MagicMock()
+        mock_table.properties = {}
+        if metadata_json is not None:
+            mock_table.properties["dbport.metadata_json"] = metadata_json
+        return mock_table
+
+    def test_inspect_input_resolves_latest_version_snapshot_and_rows(self):
+        import json
+
+        metadata_json = json.dumps(
+            {
+                "last_updated_data_at": "2026-03-14",
+                "versions": [
+                    {"version": "2026-03-14", "iceberg_snapshot_id": 99},
+                ],
+            }
+        )
+        adapter = IcebergCatalogAdapter(_make_creds())
+        mock_catalog = MagicMock()
+        mock_table = self._make_table(metadata_json=metadata_json)
+        mock_table.snapshot_by_id.return_value = MagicMock(timestamp_ms=123456)
+        mock_table.scan.return_value.to_arrow_batch_reader.return_value = [
+            pa.record_batch({"id": [1, 2, 3, 4, 5, 6, 7]})
+        ]
+        mock_catalog.load_table.return_value = mock_table
+        adapter._catalog = mock_catalog
+
+        record = adapter.inspect_input(InputDeclaration(table_address="wifor.foo"))
+
+        assert record.version == "2026-03-14"
+        assert record.last_snapshot_id == 99
+        assert record.last_snapshot_timestamp_ms == 123456
+        assert record.rows_loaded == 7
+
+    def test_inspect_input_rejects_explicit_version_without_dbport_metadata(self):
+        adapter = IcebergCatalogAdapter(_make_creds())
+        mock_catalog = MagicMock()
+        mock_table = self._make_table(metadata_json=None)
+        mock_table.current_snapshot.return_value = MagicMock(snapshot_id=42, timestamp_ms=777)
+        mock_catalog.load_table.return_value = mock_table
+        adapter._catalog = mock_catalog
+        adapter.get_table_property = lambda addr, key: None
+
+        with pytest.raises(ValueError, match="cannot be resolved"):
+            adapter.inspect_input(InputDeclaration(table_address="wifor.foo", version="2026-03-15"))
+
+    def test_inspect_input_uses_snapshot_summary_without_filters(self):
+        import json
+
+        metadata_json = json.dumps(
+            {
+                "last_updated_data_at": "2026-03-14",
+                "versions": [
+                    {"version": "2026-03-14", "iceberg_snapshot_id": 99},
+                ],
+            }
+        )
+        adapter = IcebergCatalogAdapter(_make_creds())
+        mock_catalog = MagicMock()
+        mock_table = self._make_table(metadata_json=metadata_json)
+        mock_table.snapshot_by_id.return_value = MagicMock(
+            timestamp_ms=123456,
+            summary={"total-records": "1234"},
+        )
+        mock_catalog.load_table.return_value = mock_table
+        adapter._catalog = mock_catalog
+
+        record = adapter.inspect_input(InputDeclaration(table_address="wifor.foo"))
+
+        assert record.rows_loaded == 1234
+        mock_table.scan.assert_not_called()
+
+    def test_inspect_input_handles_pyiceberg_summary_iteration_shape(self):
+        import json
+
+        class _SummaryLike(dict):
+            def __iter__(self):
+                yield ("total-records", "1234")
+
+        metadata_json = json.dumps(
+            {
+                "last_updated_data_at": "2026-03-14",
+                "versions": [
+                    {"version": "2026-03-14", "iceberg_snapshot_id": 99},
+                ],
+            }
+        )
+        adapter = IcebergCatalogAdapter(_make_creds())
+        mock_catalog = MagicMock()
+        mock_table = self._make_table(metadata_json=metadata_json)
+        mock_table.snapshot_by_id.return_value = MagicMock(
+            timestamp_ms=123456,
+            summary=_SummaryLike(),
+        )
+        mock_catalog.load_table.return_value = mock_table
+        adapter._catalog = mock_catalog
+
+        record = adapter.inspect_input(InputDeclaration(table_address="wifor.foo"))
+
+        assert record.rows_loaded == 1234
+        mock_table.scan.assert_not_called()
 
 
 class TestCatalogConnectionFailures:
@@ -893,7 +1005,9 @@ class TestCurrentSnapshotMetadataFallbackException:
         # current_snapshot() raises
         mock_table.current_snapshot.side_effect = Exception("snap error")
         # metadata access also raises (property that throws)
-        type(mock_table).metadata = property(lambda self: (_ for _ in ()).throw(Exception("meta broken")))
+        type(mock_table).metadata = property(
+            lambda self: (_ for _ in ()).throw(Exception("meta broken"))
+        )
         mock_catalog.load_table.return_value = mock_table
         adapter._catalog = mock_catalog
         assert adapter.current_snapshot("wifor.foo") == (None, None)
@@ -925,6 +1039,7 @@ class TestStreamingArrowCommitFailedImportError:
         version = DatasetVersion(version="2026-03-09")
         mock_compute = MagicMock()
         import pyarrow as pa
+
         empty_reader = pa.RecordBatchReader.from_batches(
             pa.schema([pa.field("x", pa.int32())]),
             [],
@@ -950,7 +1065,7 @@ class TestProgressCallbackIntegration:
         from dbport.infrastructure.progress import progress_callback
 
         arrow_schema = pa.schema([pa.field("id", pa.int32())])
-        arrow_table = pa.table({"id": [1, 2, 3]})
+        arrow_table = pa.table({"id": pa.array([1, 2, 3], type=pa.int32())})
         reader = pa.RecordBatchReader.from_batches(arrow_schema, arrow_table.to_batches())
 
         mock_scan = MagicMock()
@@ -966,12 +1081,15 @@ class TestProgressCallbackIntegration:
         compute = MagicMock()
         compute.execute.return_value.fetchone.return_value = (3,)
 
+        def _consume_registered_reader(_view_name, arrow_object):
+            arrow_object.read_all()
+
+        compute.register_arrow.side_effect = _consume_registered_reader
+
         cb = MagicMock()
         token = progress_callback.set(cb)
         try:
-            adapter._ingest_via_arrow(
-                InputDeclaration(table_address="estat.bar"), compute
-            )
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         finally:
             progress_callback.reset(token)
 
@@ -979,6 +1097,52 @@ class TestProgressCallbackIntegration:
         assert "estat.bar" in cb.started.call_args[0][0]
         cb.finished.assert_called_once()
         assert "3" in cb.finished.call_args[0][0]
+
+    def test_ingest_uses_snapshot_row_estimate_and_batch_updates(self):
+        """When snapshot summary exposes row totals, ingest shows determinate progress."""
+        import pyarrow as pa
+
+        from dbport.domain.entities.input import InputDeclaration
+        from dbport.infrastructure.progress import progress_callback
+
+        arrow_schema = pa.schema([pa.field("id", pa.int32())])
+        batches = [
+            pa.record_batch([pa.array([1, 2], type=pa.int32())], names=["id"]),
+            pa.record_batch([pa.array([3], type=pa.int32())], names=["id"]),
+        ]
+        reader = pa.RecordBatchReader.from_batches(arrow_schema, batches)
+
+        snapshot = MagicMock()
+        snapshot.summary = {"total-records": "3"}
+        mock_scan = MagicMock()
+        mock_scan.to_arrow_batch_reader.return_value = reader
+        mock_iceberg_table = MagicMock()
+        mock_iceberg_table.scan.return_value = mock_scan
+        mock_iceberg_table.current_snapshot.return_value = snapshot
+        mock_catalog = MagicMock()
+        mock_catalog.load_table.return_value = mock_iceberg_table
+
+        adapter = IcebergCatalogAdapter(_make_creds())
+        adapter._catalog = mock_catalog
+
+        compute = MagicMock()
+        compute.execute.return_value.fetchone.return_value = (3,)
+
+        def _consume_registered_reader(_view_name, arrow_object):
+            arrow_object.read_all()
+
+        compute.register_arrow.side_effect = _consume_registered_reader
+
+        cb = MagicMock()
+        token = progress_callback.set(cb)
+        try:
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
+        finally:
+            progress_callback.reset(token)
+
+        assert cb.started.call_args.kwargs["total"] == 3
+        cb.update.assert_any_call(2)
+        cb.update.assert_any_call(1)
 
     def test_ingest_retry_fires_failed_callback(self):
         """On transient error, the progress callback's failed() is called."""
@@ -993,13 +1157,13 @@ class TestProgressCallbackIntegration:
 
         def make_scan():
             mock_scan = MagicMock()
+
             def to_reader():
                 call_count[0] += 1
                 if call_count[0] <= 1:
                     raise OSError("InvalidKey: transient error")
-                return pa.RecordBatchReader.from_batches(
-                    arrow_schema, arrow_table.to_batches()
-                )
+                return pa.RecordBatchReader.from_batches(arrow_schema, arrow_table.to_batches())
+
             mock_scan.to_arrow_batch_reader = to_reader
             return mock_scan
 
@@ -1018,9 +1182,7 @@ class TestProgressCallbackIntegration:
         cb = MagicMock()
         token = progress_callback.set(cb)
         try:
-            adapter._ingest_via_arrow(
-                InputDeclaration(table_address="estat.bar"), compute
-            )
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         finally:
             progress_callback.reset(token)
 
@@ -1051,9 +1213,7 @@ class TestProgressCallbackIntegration:
         token = progress_callback.set(cb)
         try:
             with pytest.raises(OSError):
-                adapter._ingest_via_arrow(
-                    InputDeclaration(table_address="estat.bar"), compute
-                )
+                adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         finally:
             progress_callback.reset(token)
 
@@ -1087,8 +1247,11 @@ class TestProgressCallbackIntegration:
         token = progress_callback.set(cb)
         try:
             adapter._write_via_streaming_arrow(
-                "wifor.emp", DatasetVersion(version="2026-03-15"),
-                mock_compute, overwrite=False, total_rows=10,
+                "wifor.emp",
+                DatasetVersion(version="2026-03-15"),
+                mock_compute,
+                overwrite=False,
+                total_rows=10,
             )
         finally:
             progress_callback.reset(token)
@@ -1202,13 +1365,13 @@ class TestProgressCallbackIntegration:
 
         def make_scan():
             mock_scan = MagicMock()
+
             def to_reader():
                 call_count[0] += 1
                 if call_count[0] <= 1:
                     raise OSError("InvalidKey: transient error")
-                return pa.RecordBatchReader.from_batches(
-                    arrow_schema, arrow_table.to_batches()
-                )
+                return pa.RecordBatchReader.from_batches(arrow_schema, arrow_table.to_batches())
+
             mock_scan.to_arrow_batch_reader = to_reader
             return mock_scan
 
@@ -1228,9 +1391,7 @@ class TestProgressCallbackIntegration:
         cb = MagicMock(spec=["started", "update", "log", "finished"])
         token = progress_callback.set(cb)
         try:
-            adapter._ingest_via_arrow(
-                InputDeclaration(table_address="estat.bar"), compute
-            )
+            adapter._ingest_via_arrow(InputDeclaration(table_address="estat.bar"), compute)
         finally:
             progress_callback.reset(token)
 
@@ -1325,9 +1486,7 @@ class TestProgressCallbackIntegration:
 
         cb.log.assert_called_once_with("Switching to streaming Arrow fallback")
         # Without failed(), falls back to finished()
-        assert any(
-            "Arrow fallback" in str(c) for c in cb.finished.call_args_list
-        )
+        assert any("Arrow fallback" in str(c) for c in cb.finished.call_args_list)
 
     def test_write_versioned_duckdb_non_fallback_error_calls_finished(self):
         """write_versioned calls cb.finished() on non-fallback DuckDB errors."""

--- a/tests/test_dbport/adapters/secondary/catalog/test_writer.py
+++ b/tests/test_dbport/adapters/secondary/catalog/test_writer.py
@@ -85,10 +85,11 @@ class _FakePyicebergCatalog:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_commit_404_error():
     """Simulate the DuckDB iceberg 'transactions/commit' 404 error."""
     return Exception(
-        'TransactionContext Error: Failed to commit: Failed to commit '
+        "TransactionContext Error: Failed to commit: Failed to commit "
         'Iceberg transaction: {"message":"Route POST:/iceberg/v1/'
         'my-warehouse/transactions/commit not found","error":"Not Found",'
         '"statusCode":404}'
@@ -102,6 +103,7 @@ def _make_batch(num_rows: int) -> pa.RecordBatch:
 
 class _FakeRecordBatchReader:
     """Minimal Arrow RecordBatchReader stand-in."""
+
     def __init__(self, batches, schema=None):
         self._batches = list(batches)
         self.schema = schema or _SIMPLE_SCHEMA
@@ -168,22 +170,33 @@ class TestDuckDBWritePath:
         create_calls = [s for s in compute._sql_log if "CREATE TABLE dbport_warehouse" in s]
         assert len(create_calls) == 1
 
-    def test_overwrite_drops_then_creates(self):
+    def test_overwrite_uses_streaming_fallback(self):
         iceberg_table = _FakeIcebergTable()
         adapter = self._make_adapter(iceberg_table)
-        compute = self._mock_compute(row_count=50)
+        compute = MagicMock()
+        sql_log: list[str] = []
+
+        def execute_side_effect(sql, *args, **kwargs):
+            sql_log.append(sql)
+            result = MagicMock()
+            result.fetchone.return_value = (50,)
+            return result
+
+        def to_arrow_batches_side_effect(sql, batch_size=10_000):
+            if "LIMIT 0" in sql:
+                return _FakeRecordBatchReader([])
+            return _FakeRecordBatchReader([_make_batch(50)])
+
+        compute.execute.side_effect = execute_side_effect
+        compute.to_arrow_batches.side_effect = to_arrow_batches_side_effect
         version = DatasetVersion(version="2026-03-13")
 
         result = adapter.write_versioned("wifor.emp", version, compute, overwrite=True)
 
         assert result.rows == 50
-        drop_calls = [s for s in compute._sql_log if "DROP TABLE" in s]
-        create_calls = [s for s in compute._sql_log if "CREATE TABLE dbport_warehouse" in s]
-        assert len(drop_calls) == 1
-        assert len(create_calls) == 1
-        drop_idx = compute._sql_log.index(drop_calls[0])
-        create_idx = compute._sql_log.index(create_calls[0])
-        assert drop_idx < create_idx
+        assert not any("DROP TABLE" in s for s in sql_log)
+        assert not any("CREATE TABLE dbport_warehouse" in s for s in sql_log)
+        assert adapter._catalog._dropped is True
 
     def test_skips_when_already_completed(self):
         props = {
@@ -200,7 +213,8 @@ class TestDuckDBWritePath:
         assert result.rows == 42
         assert result.completed is True
         write_calls = [
-            s for s in compute._sql_log
+            s
+            for s in compute._sql_log
             if any(kw in s for kw in ("INSERT INTO", "CREATE TABLE", "DROP TABLE"))
         ]
         assert len(write_calls) == 0
@@ -264,8 +278,9 @@ class TestStreamingArrowFallback:
         def execute_side_effect(sql, *args, **kwargs):
             upper = sql.strip().upper()
             # DuckDB writes trigger the 404 error
-            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or \
-               upper.startswith("CREATE TABLE DBPORT_WAREHOUSE"):
+            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or upper.startswith(
+                "CREATE TABLE DBPORT_WAREHOUSE"
+            ):
                 raise _make_commit_404_error()
             if upper.startswith("DROP TABLE DBPORT_WAREHOUSE"):
                 raise _make_commit_404_error()
@@ -292,6 +307,7 @@ class TestStreamingArrowFallback:
 
         # Patch pa.Table.from_batches for the fallback
         import pyarrow as pa
+
         orig = pa.Table.from_batches
 
         result = adapter.write_versioned("wifor.emp", version, compute)
@@ -319,16 +335,14 @@ class TestStreamingArrowFallback:
         version2 = DatasetVersion(version="v2")
         # Count DuckDB write attempts
         duckdb_calls_before = [
-            c for c in compute.execute.call_args_list
-            if "dbport_warehouse" in str(c).upper()
+            c for c in compute.execute.call_args_list if "dbport_warehouse" in str(c).upper()
         ]
 
         adapter.write_versioned("wifor.emp", version2, compute)
 
         # No new DuckDB warehouse write attempts
         duckdb_calls_after = [
-            c for c in compute.execute.call_args_list
-            if "dbport_warehouse" in str(c).upper()
+            c for c in compute.execute.call_args_list if "dbport_warehouse" in str(c).upper()
         ]
         assert len(duckdb_calls_after) == len(duckdb_calls_before)
 
@@ -389,7 +403,10 @@ class TestStreamingArrowFallback:
 
         version = DatasetVersion(version="2026-03-14")
         result = adapter.write_versioned(
-            "wifor.emp", version, compute, overwrite=True,
+            "wifor.emp",
+            version,
+            compute,
+            overwrite=True,
         )
 
         assert result.rows == 30
@@ -475,9 +492,7 @@ class TestDuckDBWriteUnsupportedDetection:
         assert IcebergCatalogAdapter._is_duckdb_write_unsupported(exc) is True
 
     def test_detects_s3_403_forbidden_during_commit(self):
-        exc = Exception(
-            "Failed to commit Iceberg transaction: HTTP 403 Forbidden"
-        )
+        exc = Exception("Failed to commit Iceberg transaction: HTTP 403 Forbidden")
         assert IcebergCatalogAdapter._is_duckdb_write_unsupported(exc) is True
 
     def test_non_matching_errors_return_false(self):
@@ -515,6 +530,7 @@ class TestStreamingArrowCommitConflict:
 
     def test_commit_conflict_exhausts_max_retries(self):
         """5 consecutive commit conflicts -> RuntimeError."""
+
         class _ConflictTable:
             def __init__(self):
                 self._props = {}
@@ -543,6 +559,7 @@ class TestStreamingArrowCommitConflict:
             def commit_transaction(self):
                 try:
                     from pyiceberg.exceptions import CommitFailedException
+
                     raise CommitFailedException("branch main has changed")
                 except ImportError:
                     raise Exception("branch main has changed")
@@ -578,6 +595,7 @@ class TestStreamingArrowCommitConflict:
     def test_empty_batches_skipped(self):
         """Batches with num_rows == 0 don't trigger transactions."""
         import pyarrow as pa
+
         empty_batch = pa.record_batch({"x": pa.array([], type=pa.int64())}, schema=_SIMPLE_SCHEMA)
         real_batch = _make_batch(10)
 
@@ -602,6 +620,7 @@ class TestStreamingArrowCommitConflict:
 
     def test_non_conflict_commit_failure_propagates(self):
         """CommitFailedException without 'branch main' message raises immediately."""
+
         class _OtherFailTable:
             def __init__(self):
                 self._props = {}
@@ -630,6 +649,7 @@ class TestStreamingArrowCommitConflict:
             def commit_transaction(self):
                 try:
                     from pyiceberg.exceptions import CommitFailedException
+
                     raise CommitFailedException("permission denied")
                 except ImportError:
                     raise Exception("permission denied")
@@ -742,8 +762,9 @@ class TestWriteVersionedCheckpointRecovery:
 
         def execute_side_effect(sql, *args, **kwargs):
             upper = sql.strip().upper()
-            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or \
-               upper.startswith("CREATE TABLE DBPORT_WAREHOUSE"):
+            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or upper.startswith(
+                "CREATE TABLE DBPORT_WAREHOUSE"
+            ):
                 raise Exception(
                     "Failed to commit Iceberg transaction: the authorization mechanism "
                     "you have provided is not supported"
@@ -776,48 +797,51 @@ class TestWriteVersionedEdgeCases:
         adapter._catalog = _FakePyicebergCatalog(iceberg_table)
         return adapter
 
-    def test_overwrite_drop_exception_swallowed(self):
-        """In _write_via_duckdb overwrite mode, DROP TABLE exception is swallowed."""
+    def test_overwrite_skips_duckdb_drop_path(self):
+        """Overwrite writes bypass the DuckDB DROP/CREATE path."""
         adapter = self._make_adapter()
         compute = MagicMock()
         sql_log = []
 
         def execute_side_effect(sql, *args, **kwargs):
             sql_log.append(sql)
-            if "DROP TABLE" in sql:
-                raise Exception("table does not exist")
             result = MagicMock()
             result.fetchone.return_value = (5,)
             return result
 
+        def to_arrow_batches_side_effect(sql, batch_size=10_000):
+            if "LIMIT 0" in sql:
+                return _FakeRecordBatchReader([])
+            return _FakeRecordBatchReader([_make_batch(5)])
+
         compute.execute.side_effect = execute_side_effect
+        compute.to_arrow_batches.side_effect = to_arrow_batches_side_effect
         version = DatasetVersion(version="v1")
         result = adapter.write_versioned("wifor.emp", version, compute, overwrite=True)
         assert result.completed is True
-        # DROP was attempted, CREATE succeeded
-        assert any("DROP TABLE" in s for s in sql_log)
-        assert any("CREATE TABLE dbport_warehouse" in s for s in sql_log)
+        assert not any("DROP TABLE" in s for s in sql_log)
+        assert not any("CREATE TABLE dbport_warehouse" in s for s in sql_log)
 
-    def test_overwrite_create_failure_after_drop_raises(self):
-        """In overwrite mode, if DROP succeeds but CREATE fails, error propagates."""
+    def test_overwrite_fallback_error_propagates(self):
+        """Overwrite mode still propagates fallback writer errors."""
         adapter = self._make_adapter()
         compute = MagicMock()
-        sql_log = []
 
         def execute_side_effect(sql, *args, **kwargs):
-            sql_log.append(sql)
-            if "CREATE TABLE dbport_warehouse" in sql:
-                raise RuntimeError("S3 auth failed")
             result = MagicMock()
             result.fetchone.return_value = (5,)
             return result
 
+        def to_arrow_batches_side_effect(sql, batch_size=10_000):
+            if "LIMIT 0" in sql:
+                raise RuntimeError("S3 auth failed")
+            return _FakeRecordBatchReader([_make_batch(5)])
+
         compute.execute.side_effect = execute_side_effect
+        compute.to_arrow_batches.side_effect = to_arrow_batches_side_effect
         version = DatasetVersion(version="v1")
         with pytest.raises(RuntimeError, match="S3 auth failed"):
             adapter.write_versioned("wifor.emp", version, compute, overwrite=True)
-        # DROP was executed before CREATE failed
-        assert any("DROP TABLE" in s for s in sql_log)
 
     def test_non_unsupported_duckdb_error_propagates(self):
         """DuckDB write error that is NOT unsupported raises immediately."""
@@ -826,9 +850,9 @@ class TestWriteVersionedEdgeCases:
 
         def execute_side_effect(sql, *args, **kwargs):
             upper = sql.strip().upper()
-            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or upper.startswith("CREATE TABLE DBPORT_WAREHOUSE"):
-                raise RuntimeError("disk full")
-            if "DROP TABLE" in upper:
+            if upper.startswith("INSERT INTO DBPORT_WAREHOUSE") or upper.startswith(
+                "CREATE TABLE DBPORT_WAREHOUSE"
+            ):
                 raise RuntimeError("disk full")
             result = MagicMock()
             result.fetchone.return_value = (10,)
@@ -837,7 +861,7 @@ class TestWriteVersionedEdgeCases:
         compute.execute.side_effect = execute_side_effect
         version = DatasetVersion(version="v1")
         with pytest.raises(RuntimeError, match="disk full"):
-            adapter.write_versioned("wifor.emp", version, compute, overwrite=True)
+            adapter.write_versioned("wifor.emp", version, compute, overwrite=False)
 
     def test_snapshot_timestamp_converted_when_present(self):
         """write_versioned converts snap_ts_ms to datetime when not None."""

--- a/tests/test_dbport/application/services/test_ingest.py
+++ b/tests/test_dbport/application/services/test_ingest.py
@@ -9,7 +9,7 @@ import pytest
 from dbport.adapters.secondary.compute.duckdb import DuckDBComputeAdapter
 from dbport.adapters.secondary.lock.toml import TomlLockAdapter
 from dbport.application.services.ingest import IngestService
-from dbport.domain.entities.input import InputDeclaration
+from dbport.domain.entities.input import IngestRecord, InputDeclaration
 
 # ---------------------------------------------------------------------------
 # Test doubles
@@ -33,6 +33,16 @@ class _FakeCatalog:
 
     def current_snapshot(self, table_address):
         return self._snapshot_id, None
+
+    def inspect_input(self, declaration):
+        return IngestRecord(
+            table_address=declaration.table_address,
+            last_snapshot_id=self._snapshot_id,
+            last_snapshot_timestamp_ms=123456,
+            rows_loaded=2,
+            filters=declaration.filters,
+            version=declaration.version or self._dbport_version,
+        )
 
     def ingest_into_compute(self, declaration, compute, snapshot_id=None):
         """Seed two rows directly into DuckDB without any Arrow/S3 involvement."""
@@ -121,6 +131,18 @@ class TestIngestServiceLoad:
         record = svc.execute(declaration)
         assert record.filters == {"wstatus": "EMP"}
 
+    def test_configure_persists_record_without_loading(self, compute, lock):
+        catalog = _FakeCatalog(snapshot_id=41, dbport_version="2026-03-14")
+        svc = IngestService(catalog, compute, lock)
+        declaration = InputDeclaration(table_address="wifor.emp", filters={"geo": "DE"})
+
+        record = svc.configure(declaration)
+
+        assert record.last_snapshot_id == 41
+        assert record.version == "2026-03-14"
+        assert catalog.ingest_called == []
+        assert lock.read_ingest_records()[0] == record
+
 
 class TestIngestServiceSkip:
     def test_skips_when_snapshot_unchanged_and_relation_exists(self, compute, lock):
@@ -207,9 +229,7 @@ class TestIngestServiceVersionPinning:
         """An explicit version is forwarded to resolve_input_snapshot."""
         catalog = _FakeCatalog(snapshot_id=77, dbport_version="2026-01-01")
         svc = IngestService(catalog, compute, lock)
-        record = svc.execute(
-            InputDeclaration(table_address="wifor.emp", version="2025-01-01")
-        )
+        record = svc.execute(InputDeclaration(table_address="wifor.emp", version="2025-01-01"))
         assert record.version == "2025-01-01"
         assert record.last_snapshot_id == 77
 

--- a/tests/test_dbport/application/services/test_run.py
+++ b/tests/test_dbport/application/services/test_run.py
@@ -61,11 +61,14 @@ class _FakePort:
 
 
 class TestRunServiceNoHook:
-    def test_raises_when_no_hook_configured(self):
+    def test_defaults_to_main_py(self, tmp_path: Path):
+        hook_file = tmp_path / "main.py"
+        hook_file.write_text("port.execute('SELECT 1')", encoding="utf-8")
+
         svc = RunService(_FakeCompute(), _FakeLock(run_hook=None))
-        port = _FakePort("/tmp")
-        with pytest.raises(RuntimeError, match="No run_hook configured"):
-            svc.execute(port)
+        port = _FakePort(str(tmp_path))
+        svc.execute(port)
+        assert port.executed == ["SELECT 1"]
 
 
 class TestRunServiceSqlHook:

--- a/tests/test_dbport/application/services/test_schema.py
+++ b/tests/test_dbport/application/services/test_schema.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pyarrow as pa
 import pytest
 
+from dbport.adapters.secondary.catalog.drift import SchemaDriftError
 from dbport.adapters.secondary.compute.duckdb import DuckDBComputeAdapter
 from dbport.adapters.secondary.lock.toml import TomlLockAdapter
 from dbport.application.services.schema import DefineSchemaService
@@ -124,3 +126,26 @@ class TestDefineSchemaServicePathTraversal:
         svc = DefineSchemaService(compute, lock)
         schema = svc.execute(str(sql_file), base_dir="/ignored")
         assert len(schema.columns) == 3
+
+
+class _FakeCatalog:
+    def __init__(self, schema: pa.Schema, exists: bool = True):
+        self._schema = schema
+        self._exists = exists
+
+    def table_exists(self, _table_address: str) -> bool:
+        return self._exists
+
+    def load_arrow_schema(self, _table_address: str) -> pa.Schema:
+        return self._schema
+
+
+class TestDefineSchemaServiceSchemaDrift:
+    def test_schema_drift_fails_early(self, compute, lock):
+        svc = DefineSchemaService(compute, lock).with_catalog(
+            _FakeCatalog(pa.schema([("id", pa.int64())])),
+            "inputs.emp",
+        )
+
+        with pytest.raises(SchemaDriftError, match="Schema drift detected"):
+            svc.execute(_DDL, base_dir="/tmp")

--- a/tests/test_dbport/application/services/test_sync.py
+++ b/tests/test_dbport/application/services/test_sync.py
@@ -109,9 +109,7 @@ class TestSyncInputs:
         )
         svc, catalog, compute, lock = self._make_service(records=[record])
 
-        with patch(
-            "dbport.application.services.ingest.IngestService"
-        ) as MockIngest:
+        with patch("dbport.application.services.ingest.IngestService") as MockIngest:
             mock_ingest = MagicMock()
             MockIngest.return_value = mock_ingest
             svc.execute("test.tbl")
@@ -130,9 +128,7 @@ class TestSyncInputs:
         )
         svc, catalog, compute, lock = self._make_service(records=[record])
 
-        with patch(
-            "dbport.application.services.ingest.IngestService"
-        ) as MockIngest:
+        with patch("dbport.application.services.ingest.IngestService") as MockIngest:
             mock_ingest = MagicMock()
             mock_ingest.execute.side_effect = RuntimeError("network error")
             MockIngest.return_value = mock_ingest
@@ -150,9 +146,7 @@ class TestSyncInputs:
         cb = MagicMock()
         token = progress_callback.set(cb)
         try:
-            with patch(
-                "dbport.application.services.ingest.IngestService"
-            ) as MockIngest:
+            with patch("dbport.application.services.ingest.IngestService") as MockIngest:
                 mock_ingest = MagicMock()
                 mock_ingest.execute.side_effect = RuntimeError("fail")
                 MockIngest.return_value = mock_ingest
@@ -160,6 +154,7 @@ class TestSyncInputs:
         finally:
             progress_callback.reset(token)
 
+        cb.log.assert_called_once_with("Failed to sync estat.bad: fail")
         cb.failed.assert_called_once_with("Failed to sync estat.bad")
 
     def test_syncs_input_with_filters_and_version(self):
@@ -173,9 +168,7 @@ class TestSyncInputs:
         )
         svc, catalog, compute, lock = self._make_service(records=[record])
 
-        with patch(
-            "dbport.application.services.ingest.IngestService"
-        ) as MockIngest:
+        with patch("dbport.application.services.ingest.IngestService") as MockIngest:
             mock_ingest = MagicMock()
             MockIngest.return_value = mock_ingest
             svc.execute("test.tbl")

--- a/tests/test_dbport/cli/test_check.py
+++ b/tests/test_dbport/cli/test_check.py
@@ -1,4 +1,4 @@
-"""Tests for dbp check command."""
+"""Tests for dbp status check command."""
 
 from __future__ import annotations
 
@@ -17,19 +17,29 @@ class TestCheckCommand:
     def test_check_basic_passes(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text('[models."a.b"]\nagency = "a"\ndataset_id = "b"\n')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert result.exit_code == 0
         assert "PASS" in result.output
         assert "All checks passed" in result.output
 
     def test_check_missing_lockfile(self, tmp_path: Path):
-        result = runner.invoke(app, [
-            "--lockfile", str(tmp_path / "nope.lock"),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(tmp_path / "nope.lock"),
+                "status",
+                "check",
+            ],
+        )
         # Missing lockfile is a FAIL, so exit code is 1
         assert result.exit_code == 1
         assert "FAIL" in result.output
@@ -38,11 +48,16 @@ class TestCheckCommand:
     def test_check_json_output(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# valid toml\n")
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert "checks" in data["data"]
@@ -56,39 +71,60 @@ class TestCheckCommand:
         monkeypatch.delenv("ICEBERG_CATALOG_TOKEN", raising=False)
         monkeypatch.delenv("ICEBERG_WAREHOUSE", raising=False)
         monkeypatch.chdir(tmp_path)  # no .env file here
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check", "--strict",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+                "--strict",
+            ],
+        )
         assert result.exit_code != 0
 
     def test_check_duckdb_passes(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# ok\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert "duckdb" in result.output
         assert "PASS" in result.output
 
     def test_check_dependencies_pass(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# ok\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert "dependencies" in result.output
         assert "PASS" in result.output
 
     def test_check_invalid_toml(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("not valid {{{{ toml !!!!\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert result.exit_code == 1
         assert "FAIL" in result.output
 
@@ -96,10 +132,15 @@ class TestCheckCommand:
         """When credentials are available, check should pass."""
         lock = tmp_path / "dbport.lock"
         lock.write_text("# ok\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert "credentials" in result.output
         # In this env, creds are present
         assert "PASS" in result.output
@@ -111,11 +152,16 @@ class TestCheckCommand:
         monkeypatch.delenv("ICEBERG_CATALOG_TOKEN", raising=False)
         monkeypatch.delenv("ICEBERG_WAREHOUSE", raising=False)
         monkeypatch.chdir(tmp_path)
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         data = json.loads(result.output)
         cred_check = [c for c in data["data"]["checks"] if c["name"] == "credentials"][0]
         assert cred_check["status"] == "warn"
@@ -127,11 +173,17 @@ class TestCheckCommand:
         monkeypatch.delenv("ICEBERG_CATALOG_TOKEN", raising=False)
         monkeypatch.delenv("ICEBERG_WAREHOUSE", raising=False)
         monkeypatch.chdir(tmp_path)
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "check", "--strict",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+                "--strict",
+            ],
+        )
         assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["ok"] is False
@@ -146,10 +198,15 @@ class TestCheckCommand:
         mock_duckdb.__version__ = _real_duckdb.__version__
 
         with patch.dict("sys.modules", {"duckdb": mock_duckdb}):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "check",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "status",
+                    "check",
+                ],
+            )
         # DuckDB failure is a FAIL
         assert result.exit_code == 1
         assert "FAIL" in result.output
@@ -164,19 +221,27 @@ class TestCheckCommand:
         fake_creds.catalog_token = ""
         fake_creds.warehouse = ""
 
-        with patch("dbport.cli.commands.check.WarehouseCreds", return_value=fake_creds, create=True):
+        with patch(
+            "dbport.cli.commands.check.WarehouseCreds", return_value=fake_creds, create=True
+        ):
             # Force the import inside check to use our mock
             import dbport.cli.commands.check as check_mod
+
             original = check_mod.check_cmd
 
             def patched_check(ctx, strict=False):
                 # Monkey-patch the import inside check_cmd
                 return original(ctx, strict)
 
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "check",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "status",
+                    "check",
+                ],
+            )
 
         # With real code, the try branch uses __import__ so we need a different approach
         # Let's directly patch the WarehouseCreds class at the source
@@ -184,10 +249,15 @@ class TestCheckCommand:
 
         fake = SimpleNamespace(catalog_uri="", catalog_token="", warehouse="")
         with patch("dbport.infrastructure.credentials.WarehouseCreds", return_value=fake):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "check",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "status",
+                    "check",
+                ],
+            )
         assert "WARN" in result.output
         assert "credentials" in result.output
         assert "ICEBERG_REST_URI" in result.output
@@ -202,12 +272,19 @@ class TestCheckCommand:
         monkeypatch.setenv("ICEBERG_WAREHOUSE", "wh")
 
         # Force WarehouseCreds() to raise even though env vars exist
-        with patch("dbport.infrastructure.credentials.WarehouseCreds", side_effect=Exception("forced")):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "check",
-            ])
+        with patch(
+            "dbport.infrastructure.credentials.WarehouseCreds", side_effect=Exception("forced")
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "status",
+                    "check",
+                ],
+            )
         data = json.loads(result.output)
         cred_check = [c for c in data["data"]["checks"] if c["name"] == "credentials"][0]
         assert cred_check["status"] == "warn"
@@ -218,7 +295,11 @@ class TestCheckCommand:
         lock = tmp_path / "dbport.lock"
         lock.write_text("# ok\n")
 
-        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+        real_import = (
+            __builtins__["__import__"]
+            if isinstance(__builtins__, dict)
+            else __builtins__.__import__
+        )
 
         def selective_import(name, *args, **kwargs):
             if name == "pyarrow":
@@ -226,11 +307,16 @@ class TestCheckCommand:
             return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=selective_import):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "check",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "status",
+                    "check",
+                ],
+            )
         data = json.loads(result.output)
         dep_check = [c for c in data["data"]["checks"] if c["name"] == "dependencies"][0]
         assert dep_check["status"] == "fail"

--- a/tests/test_dbport/cli/test_config.py
+++ b/tests/test_dbport/cli/test_config.py
@@ -30,46 +30,69 @@ def _write_lock(repo: Path, content: str) -> Path:
 class TestConfigDefaultShow:
     def test_show_when_no_lock_file(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+            ],
+        )
         assert result.exit_code == 0
         assert "No default model" in result.output
 
     def test_show_when_no_default_set(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+            ],
+        )
         assert result.exit_code == 0
         assert "No default model" in result.output
 
     def test_show_current_default(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            'default_model = "a.x"\n\n'
-            '[models."a.x"]\nagency = "a"\ndataset_id = "x"\n'
-        ))
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default",
-        ])
+        _write_lock(
+            repo, ('default_model = "a.x"\n\n[models."a.x"]\nagency = "a"\ndataset_id = "x"\n')
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+            ],
+        )
         assert result.exit_code == 0
         assert "a.x" in result.output
 
     def test_show_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            'default_model = "a.x"\n\n'
-            '[models."a.x"]\nagency = "a"\ndataset_id = "x"\n'
-        ))
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "default",
-        ])
+        _write_lock(
+            repo, ('default_model = "a.x"\n\n[models."a.x"]\nagency = "a"\ndataset_id = "x"\n')
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -78,10 +101,17 @@ class TestConfigDefaultShow:
     def test_show_json_output_no_default(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\n')
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "default",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["default_model"] is None
@@ -90,14 +120,24 @@ class TestConfigDefaultShow:
 class TestConfigDefaultSet:
     def test_set_valid_model(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n\n'
-            '[models."b.y"]\nagency = "b"\ndataset_id = "y"\nmodel_root = "sub"\n'
-        ))
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default", "b.y",
-        ])
+        _write_lock(
+            repo,
+            (
+                '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n\n'
+                '[models."b.y"]\nagency = "b"\ndataset_id = "y"\nmodel_root = "sub"\n'
+            ),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+                "b.y",
+            ],
+        )
         assert result.exit_code == 0
         assert "b.y" in result.output
 
@@ -108,20 +148,35 @@ class TestConfigDefaultSet:
     def test_set_invalid_model_errors(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default", "nonexistent.model",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+                "nonexistent.model",
+            ],
+        )
         assert result.exit_code != 0
         assert "not found" in result.output
 
     def test_set_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n')
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "default", "a.x",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+                "a.x",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -130,100 +185,80 @@ class TestConfigDefaultSet:
     def test_set_preserves_models(self, tmp_path: Path):
         """Setting default_model must not lose any model data."""
         repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            '[models."a.x"]\n'
-            'agency = "a"\n'
-            'dataset_id = "x"\n'
-            'model_root = "."\n'
-            'duckdb_path = "data/x.duckdb"\n'
-        ))
-        runner.invoke(app, [
-            "--project", str(repo),
-            "config", "default", "a.x",
-        ])
+        _write_lock(
+            repo,
+            (
+                '[models."a.x"]\n'
+                'agency = "a"\n'
+                'dataset_id = "x"\n'
+                'model_root = "."\n'
+                'duckdb_path = "data/x.duckdb"\n'
+            ),
+        )
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "model",
+                "a.x",
+            ],
+        )
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["default_model"] == "a.x"
         assert doc["models"]["a.x"]["agency"] == "a"
         assert doc["models"]["a.x"]["dataset_id"] == "x"
 
 
-# -- Shared lock content for info tests --------------------------------------
-
-_RICH_LOCK = (
-    'default_model = "test.t1"\n\n'
-    '[models."test.t1"]\n'
-    'agency = "test"\n'
-    'dataset_id = "t1"\n'
-    'model_root = "models/t1"\n'
-    'duckdb_path = "models/t1/data/t1.duckdb"\n\n'
-    '[models."test.t1".schema]\n'
-    'ddl = "CREATE TABLE test.t1 (geo VARCHAR, value DOUBLE);"\n'
-    'source = "local"\n\n'
-    '[[models."test.t1".schema.columns]]\n'
-    'column_name = "geo"\n'
-    'column_pos = 0\n'
-    'sql_type = "VARCHAR"\n\n'
-    '[[models."test.t1".schema.columns]]\n'
-    'column_name = "value"\n'
-    'column_pos = 1\n'
-    'sql_type = "DOUBLE"\n\n'
-    '[[models."test.t1".inputs]]\n'
-    'table_address = "estat.table_a"\n'
-    'last_snapshot_id = 1234567890\n'
-    'last_snapshot_timestamp_ms = 1710000000000\n'
-    'rows_loaded = 5000\n\n'
-    '[[models."test.t1".inputs]]\n'
-    'table_address = "wifor.cl_nuts"\n'
-    'last_snapshot_id = 9876543210\n'
-    'last_snapshot_timestamp_ms = 1710100000000\n'
-    'rows_loaded = 200\n\n'
-    '[[models."test.t1".versions]]\n'
-    'version = "2026-03-01"\n'
-    'published_at = 2026-03-01T10:00:00Z\n'
-    'iceberg_snapshot_id = 1111111111\n'
-    'rows = 4800\n'
-    'completed = true\n\n'
-    '[[models."test.t1".versions]]\n'
-    'version = "2026-03-14"\n'
-    'published_at = 2026-03-14T12:00:00Z\n'
-    'iceberg_snapshot_id = 2222222222\n'
-    'rows = 5000\n'
-    'completed = true\n\n'
-    '[models."test.t2"]\n'
-    'agency = "test"\n'
-    'dataset_id = "t2"\n'
-    'model_root = "models/t2"\n'
-)
-
-
 class TestConfigFolder:
     def test_show_default_folder(self, tmp_path: Path):
         """Without any setting, models_folder defaults to 'models'."""
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "folder",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+            ],
+        )
         assert result.exit_code == 0
         assert "models" in result.output
 
     def test_show_custom_folder(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, 'models_folder = "examples"\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "folder",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+            ],
+        )
         assert result.exit_code == 0
         assert "examples" in result.output
 
     def test_set_folder(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "folder", "examples",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+                "examples",
+            ],
+        )
         assert result.exit_code == 0
         assert "examples" in result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
@@ -232,10 +267,17 @@ class TestConfigFolder:
     def test_set_folder_strips_slashes(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, "")
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "folder", "/examples/",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+                "/examples/",
+            ],
+        )
         assert result.exit_code == 0
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["models_folder"] == "examples"
@@ -243,10 +285,17 @@ class TestConfigFolder:
     def test_show_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, 'models_folder = "src/models"\n')
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "folder",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -255,10 +304,18 @@ class TestConfigFolder:
     def test_set_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, "")
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "folder", "custom",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+                "custom",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -267,18 +324,28 @@ class TestConfigFolder:
     def test_set_preserves_models(self, tmp_path: Path):
         """Setting models_folder must not lose any model data."""
         repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            'default_model = "a.x"\n\n'
-            '[models."a.x"]\n'
-            'agency = "a"\n'
-            'dataset_id = "x"\n'
-            'model_root = "."\n'
-            'duckdb_path = "data/x.duckdb"\n'
-        ))
-        runner.invoke(app, [
-            "--project", str(repo),
-            "config", "folder", "examples",
-        ])
+        _write_lock(
+            repo,
+            (
+                'default_model = "a.x"\n\n'
+                '[models."a.x"]\n'
+                'agency = "a"\n'
+                'dataset_id = "x"\n'
+                'model_root = "."\n'
+                'duckdb_path = "data/x.duckdb"\n'
+            ),
+        )
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "folder",
+                "examples",
+            ],
+        )
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["models_folder"] == "examples"
         assert doc["default_model"] == "a.x"
@@ -308,42 +375,86 @@ class TestConfigRunHook:
     def test_show_current_hook(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, self._LOCK_WITH_HOOK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "run-hook",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+            ],
+        )
         assert result.exit_code == 0
         assert "sql/main.sql" in result.output
 
     def test_show_no_hook_set(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, self._LOCK_NO_HOOK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "run-hook",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+            ],
+        )
         assert result.exit_code == 0
-        assert "No run hook" in result.output
+        assert "main.py" in result.output
 
     def test_show_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, self._LOCK_WITH_HOOK)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "run-hook",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["run_hook"] == "sql/main.sql"
         assert data["data"]["model"] == "a.x"
 
+    def test_show_json_output_uses_main_py_default(self, tmp_path: Path):
+        repo = _setup_repo(tmp_path)
+        _write_lock(repo, self._LOCK_NO_HOOK)
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["data"]["run_hook"] == "main.py"
+
     def test_set_hook(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, self._LOCK_NO_HOOK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "run-hook", "sql/transform.sql",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+                "sql/transform.sql",
+            ],
+        )
         assert result.exit_code == 0
         assert "sql/transform.sql" in result.output
 
@@ -354,10 +465,18 @@ class TestConfigRunHook:
     def test_set_hook_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, self._LOCK_NO_HOOK)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "run-hook", "run.py",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "default",
+                "hook",
+                "run.py",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["run_hook"] == "run.py"
@@ -383,240 +502,23 @@ class TestConfigRunHook:
         old_cwd = os.getcwd()
         try:
             os.chdir(str(repo))
-            result = runner.invoke(app, [
-                "--project", str(repo),
-                "config", "run-hook", "models/x/sql/main.sql",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--project",
+                    str(repo),
+                    "config",
+                    "default",
+                    "hook",
+                    "models/x/sql/main.sql",
+                ],
+            )
         finally:
             os.chdir(old_cwd)
 
         assert result.exit_code == 0
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["models"]["a.x"]["run_hook"] == "sql/main.sql"
-
-
-class TestConfigInfo:
-    def test_info_default_summary(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0, result.output
-        assert "test.t1" in result.output
-        assert "models/t1" in result.output
-        assert "2 columns" in result.output
-        assert "2" in result.output  # inputs or versions count
-
-    def test_info_inputs_flag(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--inputs",
-        ])
-        assert result.exit_code == 0, result.output
-        assert "estat.table_a" in result.output
-        assert "wifor.cl_nuts" in result.output
-        assert "5000" in result.output
-
-    def test_info_history_flag(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--history",
-        ])
-        assert result.exit_code == 0, result.output
-        assert "2026-03-01" in result.output
-        assert "2026-03-14" in result.output
-        assert "4800" in result.output
-
-    def test_info_raw_flag(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--raw",
-        ])
-        assert result.exit_code == 0, result.output
-        # Raw output should contain the TOML content directly
-        assert 'default_model = "test.t1"' in result.output
-        assert '[models."test.t1"]' in result.output
-
-    def test_info_combined_inputs_history(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--inputs", "--history",
-        ])
-        assert result.exit_code == 0, result.output
-        # Both tables should appear
-        assert "estat.table_a" in result.output
-        assert "2026-03-14" in result.output
-
-    def test_info_json_output(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "info", "--inputs", "--history",
-        ])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["ok"] is True
-        assert data["data"]["model_key"] == "test.t1"
-        assert data["data"]["default_model"] == "test.t1"
-        assert data["data"]["column_count"] == 2
-        assert data["data"]["input_count"] == 2
-        assert data["data"]["version_count"] == 2
-        assert len(data["data"]["inputs"]) == 2
-        assert len(data["data"]["versions"]) == 2
-        assert data["data"]["inputs"][0]["table_address"] == "estat.table_a"
-        assert data["data"]["versions"][1]["version"] == "2026-03-14"
-
-    def test_info_no_lock_file(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        assert "No dbport.lock" in result.output
-
-    def test_info_respects_model_flag(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "--model", "models/t2",
-            "config", "info",
-        ])
-        assert result.exit_code == 0, result.output
-        assert "test.t2" in result.output
-
-    def test_info_raw_json(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "info", "--raw",
-        ])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["ok"] is True
-        assert 'default_model' in data["data"]["raw"]
-
-    def test_info_no_models_in_lock(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, "# just a comment\n")
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        assert "No models found" in result.output
-
-    def test_info_no_models_json(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, "# empty\n")
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["ok"] is False
-
-    def test_info_no_lock_json(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["data"].get("error") is not None
-
-    def test_info_raw_no_lock(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--raw",
-        ])
-        assert result.exit_code == 0
-        assert "No dbport.lock" in result.output
-
-    def test_info_no_schema_defined(self, tmp_path: Path):
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        assert "not defined" in result.output
-
-    def test_info_json_without_inputs_history(self, tmp_path: Path):
-        """JSON output without --inputs/--history should not include those keys."""
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, _RICH_LOCK)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "info",
-        ])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert "inputs" not in data["data"]
-        assert "versions" not in data["data"]
-        assert data["data"]["input_count"] == 2
-        assert data["data"]["version_count"] == 2
-
-    def test_info_history_flag_no_versions(self, tmp_path: Path):
-        """Cover branch: --history flag true but model has no versions."""
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--history",
-        ])
-        assert result.exit_code == 0
-        # Should show summary but no history table (no versions to display)
-        assert "a.x" in result.output
-
-    def test_info_inputs_flag_no_inputs(self, tmp_path: Path):
-        """Cover branch: --inputs flag true but model has no inputs."""
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, '[models."a.x"]\nagency = "a"\ndataset_id = "x"\nmodel_root = "."\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--inputs",
-        ])
-        assert result.exit_code == 0
-        assert "a.x" in result.output
-
-    def test_info_inputs_without_timestamp(self, tmp_path: Path):
-        """Cover branch: input has no last_snapshot_timestamp_ms (ts is falsy)."""
-        repo = _setup_repo(tmp_path)
-        _write_lock(repo, (
-            'default_model = "a.x"\n\n'
-            '[models."a.x"]\n'
-            'agency = "a"\n'
-            'dataset_id = "x"\n'
-            'model_root = "."\n\n'
-            '[[models."a.x".inputs]]\n'
-            'table_address = "ns.tbl"\n'
-            'rows_loaded = 100\n'
-            # No last_snapshot_timestamp_ms
-        ))
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "info", "--inputs",
-        ])
-        assert result.exit_code == 0
-        assert "ns.tbl" in result.output
 
 
 # -- Lock content with schema columns for meta/attach tests ------------------
@@ -633,17 +535,17 @@ _LOCK_WITH_SCHEMA = (
     'source = "local"\n\n'
     '[[models."a.x".schema.columns]]\n'
     'column_name = "geo"\n'
-    'column_pos = 0\n'
+    "column_pos = 0\n"
     'sql_type = "VARCHAR"\n'
     'codelist_id = "geo"\n\n'
     '[[models."a.x".schema.columns]]\n'
     'column_name = "year"\n'
-    'column_pos = 1\n'
+    "column_pos = 1\n"
     'sql_type = "INTEGER"\n'
     'codelist_id = "year"\n\n'
     '[[models."a.x".schema.columns]]\n'
     'column_name = "value"\n'
-    'column_pos = 2\n'
+    "column_pos = 2\n"
     'sql_type = "DOUBLE"\n'
     'codelist_id = "value"\n'
 )
@@ -658,14 +560,21 @@ _LOCK_NO_SCHEMA = (
 )
 
 
-class TestConfigMeta:
+class TestConfigColumns:
     def test_show_columns_with_schema(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "geo" in result.output
         assert "year" in result.output
@@ -674,20 +583,35 @@ class TestConfigMeta:
     def test_show_no_columns(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_NO_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+            ],
+        )
         assert result.exit_code == 0
         assert "No columns defined" in result.output
 
     def test_show_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "meta",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -697,10 +621,21 @@ class TestConfigMeta:
     def test_set_codelist_id(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta", "geo", "--id", "GEO_NUTS",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "set",
+                "geo",
+                "--id",
+                "GEO_NUTS",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Updated metadata" in result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
@@ -711,10 +646,23 @@ class TestConfigMeta:
     def test_set_kind_and_type(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta", "geo", "--kind", "hierarchical", "--type", "reference",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "set",
+                "geo",
+                "--kind",
+                "hierarchical",
+                "--type",
+                "reference",
+            ],
+        )
         assert result.exit_code == 0, result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         cols = doc["models"]["a.x"]["schema"]["columns"]
@@ -725,11 +673,21 @@ class TestConfigMeta:
     def test_set_labels(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta", "geo",
-            "--labels", '{"en": "Geography", "de": "Geographie"}',
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "set",
+                "geo",
+                "--labels",
+                '{"en": "Geography", "de": "Geographie"}',
+            ],
+        )
         assert result.exit_code == 0, result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         cols = doc["models"]["a.x"]["schema"]["columns"]
@@ -740,19 +698,42 @@ class TestConfigMeta:
         """Setting meta on a column not in schema creates a new entry."""
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "meta", "new_col", "--id", "NEW",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "set",
+                "new_col",
+                "--id",
+                "NEW",
+            ],
+        )
         assert result.exit_code == 0, result.output
 
     def test_set_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "meta", "geo", "--id", "GEO",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "set",
+                "geo",
+                "--id",
+                "GEO",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -760,14 +741,24 @@ class TestConfigMeta:
         assert data["data"]["codelist_id"] == "GEO"
 
 
-class TestConfigAttach:
+class TestConfigColumnsAttach:
     def test_attach_table(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "attach", "geo", "--table", "wifor.cl_nuts",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "attach",
+                "geo",
+                "wifor.cl_nuts",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Attached" in result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
@@ -779,19 +770,40 @@ class TestConfigAttach:
         """Attaching to a column not in schema creates a new entry."""
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "attach", "unknown_col", "--table", "ns.tbl",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "attach",
+                "unknown_col",
+                "ns.tbl",
+            ],
+        )
         assert result.exit_code == 0, result.output
 
     def test_attach_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "attach", "geo", "--table", "wifor.cl_nuts",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "attach",
+                "geo",
+                "wifor.cl_nuts",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -801,10 +813,19 @@ class TestConfigAttach:
     def test_attach_requires_table_flag(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "attach", "geo",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "columns",
+                "attach",
+                "geo",
+            ],
+        )
         assert result.exit_code != 0
 
 
@@ -812,20 +833,35 @@ class TestConfigVersion:
     def test_version_show_none(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "version",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "version",
+            ],
+        )
         assert result.exit_code == 0
         assert "No version set" in result.output
 
     def test_version_set(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "version", "2026-03-16",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "version",
+                "2026-03-16",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "2026-03-16" in result.output
         doc = tomllib.loads((repo / "dbport.lock").read_text())
@@ -835,25 +871,49 @@ class TestConfigVersion:
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
         # First set
-        runner.invoke(app, [
-            "--project", str(repo),
-            "config", "version", "2026-03-16",
-        ])
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "version",
+                "2026-03-16",
+            ],
+        )
         # Then show
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "config", "version",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "version",
+            ],
+        )
         assert result.exit_code == 0
         assert "2026-03-16" in result.output
 
     def test_version_json_output(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _write_lock(repo, _LOCK_WITH_SCHEMA)
-        result = runner.invoke(app, [
-            "--json", "--project", str(repo),
-            "config", "version", "2026-03-16",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "config",
+                "model",
+                "a.x",
+                "version",
+                "2026-03-16",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True

--- a/tests/test_dbport/cli/test_execute.py
+++ b/tests/test_dbport/cli/test_execute.py
@@ -1,4 +1,4 @@
-"""Tests for dbp execute command (SQL transform execution)."""
+"""Tests for dbp model exec command."""
 
 from __future__ import annotations
 
@@ -20,49 +20,79 @@ def _create_lock(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-_MODEL_LOCK = '''
+_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-'''
+"""
 
 
-def _mock_dbport():
+def _mock_dbport(model_root: str = "."):
     mock_port = MagicMock()
     mock_port.__enter__ = MagicMock(return_value=mock_port)
     mock_port.__exit__ = MagicMock(return_value=False)
+    mock_port._dataset = type("D", (), {"model_root": model_root})()
+    mock_port.run_hook = "main.py"
     return mock_port
 
 
 class TestExecuteCommand:
-    def test_execute_no_target_fails(self, tmp_path: Path):
+    def test_execute_uses_configured_hook_when_no_target(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        lock.write_text('[models."a.b"]\nagency = "a"\ndataset_id = "b"\n')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "execute",
-        ])
-        assert result.exit_code != 0
-        assert "No target specified" in result.output
+        _create_lock(lock, _MODEL_LOCK)
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp = _mock_dbport(str(tmp_path))
+
+        with patch(_PATCH_TARGET, return_value=mp):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mp.execute.assert_called_once_with("SELECT 1")
 
     def test_execute_help(self):
-        result = runner.invoke(app, ["execute", "--help"])
+        result = runner.invoke(
+            app,
+            [
+                "model",
+                "exec",
+                "--help",
+            ],
+        )
         assert result.exit_code == 0
         assert "sql" in result.output.lower()
+        assert "py" in result.output.lower()
 
     def test_execute_success(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
-        mp = _mock_dbport()
+        mp = _mock_dbport(str(tmp_path))
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "execute", "sql/main.sql",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                    "a.b",
+                    "--target",
+                    "sql/main.sql",
+                ],
+            )
         assert result.exit_code == 0
         assert "Executed" in result.output
         mp.execute.assert_called_once_with("sql/main.sql")
@@ -73,11 +103,21 @@ class TestExecuteCommand:
         mp = _mock_dbport()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "execute", "sql/main.sql", "--timing",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                    "a.b",
+                    "--target",
+                    "sql/main.sql",
+                    "--timing",
+                ],
+            )
         assert result.exit_code == 0
         assert "Duration" in result.output
 
@@ -87,24 +127,90 @@ class TestExecuteCommand:
         mp = _mock_dbport()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "execute", "sql/main.sql",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                    "a.b",
+                    "--target",
+                    "sql/main.sql",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
         assert data["data"]["target"] == "sql/main.sql"
         assert "elapsed_seconds" in data["data"]
 
+    def test_exec_python_success(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp = _mock_dbport(str(tmp_path))
+
+        with patch(_PATCH_TARGET, return_value=mp):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                    "a.b",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mp.execute.assert_called_once_with("SELECT 1")
+
+    def test_exec_python_run_callable_uses_injected_port(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+        (tmp_path / "main.py").write_text(
+            "def run(port):\n"
+            "    port.execute('SELECT 2')\n\n"
+            "if __name__ == '__main__':\n"
+            "    raise RuntimeError('should not execute standalone block')\n",
+            encoding="utf-8",
+        )
+        mp = _mock_dbport(str(tmp_path))
+
+        with patch(_PATCH_TARGET, return_value=mp):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "exec",
+                    "a.b",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mp.execute.assert_called_once_with("SELECT 2")
+
     def test_execute_no_model_fails(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# empty\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "execute", "sql/main.sql",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "model",
+                "exec",
+                "--target",
+                "sql/main.sql",
+            ],
+        )
         assert result.exit_code != 0
         assert "No models found" in result.output

--- a/tests/test_dbport/cli/test_init.py
+++ b/tests/test_dbport/cli/test_init.py
@@ -26,17 +26,26 @@ def _setup_repo(tmp_path: Path) -> Path:
 class TestInitCommand:
     def test_init_creates_scaffold(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "my_project",
-            "--agency", "wifor",
-            "--dataset", "emp_test",
-            "--path", str(repo / "my_project"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "my_project",
+                "--agency",
+                "wifor",
+                "--dataset",
+                "emp_test",
+                "--path",
+                str(repo / "my_project"),
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Created model" in result.output
 
         project_dir = repo / "my_project"
+        assert (project_dir / "main.py").exists()
         assert (project_dir / "sql" / "create_output.sql").exists()
         assert (project_dir / "sql" / "main.sql").exists()
         assert (project_dir / "data").is_dir()
@@ -44,13 +53,21 @@ class TestInitCommand:
     def test_init_writes_to_repo_root_lock(self, tmp_path: Path):
         """Init must write to the repo-root dbport.lock, not model dir."""
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "test_agency",
-            "--dataset", "test_ds",
-            "--path", str(repo / "proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "test_agency",
+                "--dataset",
+                "test_ds",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         assert result.exit_code == 0, result.output
 
         # Repo-root lock should contain the model
@@ -66,13 +83,21 @@ class TestInitCommand:
     def test_init_stores_relative_model_root(self, tmp_path: Path):
         """model_root in lock must be relative to repo root."""
         repo = _setup_repo(tmp_path)
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(repo / "examples" / "proj"),
-        ])
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(repo / "examples" / "proj"),
+            ],
+        )
         lock = repo / "dbport.lock"
         doc = tomllib.loads(lock.read_text())
         model = doc["models"]["a.d"]
@@ -82,49 +107,79 @@ class TestInitCommand:
     def test_init_scaffold_ddl_no_trailing_comma(self, tmp_path: Path):
         """Generated DDL template must not have a trailing comma before closing paren."""
         repo = _setup_repo(tmp_path)
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(repo / "proj"),
-        ])
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         ddl = (repo / "proj" / "sql" / "create_output.sql").read_text()
         assert ",\n);" not in ddl, "Trailing comma before closing paren is invalid SQL"
 
-    def test_init_hybrid_template_creates_run_py(self, tmp_path: Path):
+    def test_init_hybrid_template_creates_main_py(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--template", "hybrid",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(repo / "proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--template",
+                "hybrid",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         assert result.exit_code == 0
-        assert (repo / "proj" / "run.py").exists()
+        assert (repo / "proj" / "main.py").exists()
 
-    def test_init_sql_template_no_run_py(self, tmp_path: Path):
+    def test_init_sql_template_creates_main_py(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--template", "sql",
-            "--path", str(repo / "proj"),
-        ])
-        assert not (repo / "proj" / "run.py").exists()
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--template",
+                "sql",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
+        assert (repo / "proj" / "main.py").exists()
 
     def test_init_refuses_existing_dir_without_force(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         target = repo / "proj"
         target.mkdir()
         (target / "existing_file").write_text("x")
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--path", str(target),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--path",
+                str(target),
+            ],
+        )
         assert result.exit_code != 0
         assert "already" in result.output
         assert "force" in result.output.lower()
@@ -134,26 +189,41 @@ class TestInitCommand:
         target = repo / "proj"
         target.mkdir()
         (target / "existing_file").write_text("x")
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--force",
-            "--path", str(target),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--force",
+                "--path",
+                str(target),
+            ],
+        )
         assert result.exit_code == 0
         assert "Created model" in result.output
 
     def test_init_json_output(self, tmp_path: Path):
         import json
+
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--json",
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(repo / "proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -164,53 +234,89 @@ class TestInitCommand:
 
     def test_init_invalid_template(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--template", "invalid",
-            "--path", str(repo / "proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--template",
+                "invalid",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         assert result.exit_code != 0
 
     def test_init_default_name(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init",
-            "--path", str(repo / "default_proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "--path",
+                str(repo / "default_proj"),
+            ],
+        )
         assert result.exit_code == 0
 
     def test_init_sets_default_model(self, tmp_path: Path):
         """First init should set default_model in lock file."""
         repo = _setup_repo(tmp_path)
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(repo / "proj"),
-        ])
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["default_model"] == "a.d"
 
     def test_init_updates_default_model(self, tmp_path: Path):
         """Second init should change default_model to the new model."""
         repo = _setup_repo(tmp_path)
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj1",
-            "--agency", "a",
-            "--dataset", "d1",
-            "--path", str(repo / "proj1"),
-        ])
-        runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj2",
-            "--agency", "a",
-            "--dataset", "d2",
-            "--path", str(repo / "proj2"),
-        ])
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj1",
+                "--agency",
+                "a",
+                "--dataset",
+                "d1",
+                "--path",
+                str(repo / "proj1"),
+            ],
+        )
+        runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj2",
+                "--agency",
+                "a",
+                "--dataset",
+                "d2",
+                "--path",
+                str(repo / "proj2"),
+            ],
+        )
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         assert doc["default_model"] == "a.d2"
         # Both models should still exist
@@ -219,28 +325,43 @@ class TestInitCommand:
 
     def test_init_python_template(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--template", "python",
-            "--path", str(repo / "proj"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--template",
+                "python",
+                "--path",
+                str(repo / "proj"),
+            ],
+        )
         assert result.exit_code == 0
-        assert (repo / "proj" / "run.py").exists()
-        content = (repo / "proj" / "run.py").read_text()
-        assert "DBPort" in content
+        assert (repo / "proj" / "main.py").exists()
+        content = (repo / "proj" / "main.py").read_text()
+        assert 'port.execute("sql/main.sql")' in content
 
     def test_init_target_outside_repo(self, tmp_path: Path):
         """When target dir is outside repo root, model_root should be absolute."""
         repo = _setup_repo(tmp_path)
         outside = tmp_path / "outside_proj"
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--agency", "a",
-            "--dataset", "d",
-            "--path", str(outside),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+                "--path",
+                str(outside),
+            ],
+        )
         assert result.exit_code == 0
         doc = tomllib.loads((repo / "dbport.lock").read_text())
         model = doc["models"]["a.d"]
@@ -251,12 +372,19 @@ class TestInitCommand:
         """Without --path, target should be <repo>/models/<agency>/<dataset>."""
         repo = _setup_repo(tmp_path)
         monkeypatch.chdir(repo)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "my_model",
-            "--agency", "a",
-            "--dataset", "d",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "my_model",
+                "--agency",
+                "a",
+                "--dataset",
+                "d",
+            ],
+        )
         assert result.exit_code == 0
         assert (repo / "models" / "a" / "d" / "sql" / "create_output.sql").exists()
 
@@ -266,21 +394,32 @@ class TestInitCommand:
         target = repo / "proj"
         target.mkdir()
         # Dir exists but is empty — should succeed without --force
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "proj",
-            "--path", str(target),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "proj",
+                "--path",
+                str(target),
+            ],
+        )
         assert result.exit_code == 0
         assert "Created model" in result.output
 
     def test_init_dotted_name_parses_agency_dataset(self, tmp_path: Path):
         """'dbp init test.brand_new' should parse agency=test, dataset=brand_new."""
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "test.brand_new",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.brand_new",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Created model" in result.output
         # Should be at models/test/brand_new
@@ -293,11 +432,17 @@ class TestInitCommand:
     def test_init_dotted_name_with_path_override(self, tmp_path: Path):
         """'dbp init test.brand_new --path brand_new' creates at models/brand_new."""
         repo = _setup_repo(tmp_path)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "test.brand_new",
-            "--path", "brand_new",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.brand_new",
+                "--path",
+                "brand_new",
+            ],
+        )
         assert result.exit_code == 0, result.output
         # Should be at models/brand_new (--path relative to models_folder)
         assert (repo / "models" / "brand_new" / "sql" / "create_output.sql").exists()
@@ -311,10 +456,15 @@ class TestInitCommand:
         # Set models_folder to "examples"
         lock = repo / "dbport.lock"
         lock.write_text('models_folder = "examples"\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "test.my_model",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.my_model",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert (repo / "examples" / "test" / "my_model" / "sql" / "create_output.sql").exists()
 
@@ -323,11 +473,17 @@ class TestInitCommand:
         repo = _setup_repo(tmp_path)
         lock = repo / "dbport.lock"
         lock.write_text('models_folder = "examples"\n')
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "test.thing",
-            "--path", "custom_dir",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.thing",
+                "--path",
+                "custom_dir",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert (repo / "examples" / "custom_dir" / "sql" / "create_output.sql").exists()
 
@@ -335,11 +491,17 @@ class TestInitCommand:
         """Absolute --path should bypass models_folder entirely."""
         repo = _setup_repo(tmp_path)
         abs_target = tmp_path / "absolute_target"
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "test.thing",
-            "--path", str(abs_target),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.thing",
+                "--path",
+                str(abs_target),
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert (abs_target / "sql" / "create_output.sql").exists()
 
@@ -349,16 +511,16 @@ def _create_lock(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-_EXISTING_LOCK = '''\
+_EXISTING_LOCK = """\
 [models."test.table1"]
 agency = "test"
 dataset_id = "table1"
 model_root = "examples/minimal"
 duckdb_path = "examples/minimal/data/table1.duckdb"
 run_hook = "sql/main.sql"
-'''
+"""
 
-_TWO_MODELS_LOCK = '''\
+_TWO_MODELS_LOCK = """\
 [models."test.table1"]
 agency = "test"
 dataset_id = "table1"
@@ -370,7 +532,7 @@ agency = "test"
 dataset_id = "table2"
 model_root = "examples/other"
 duckdb_path = "examples/other/data/table2.duckdb"
-'''
+"""
 
 
 def _mock_dbport():
@@ -380,50 +542,58 @@ def _mock_dbport():
     return mock_port
 
 
-class TestInitSyncExistingModel:
-    """Tests for `dbp init <model_key>` syncing an existing model."""
+class TestInitExistingModelValidation:
+    """Tests for fast failure when init targets an existing model."""
 
-    def test_init_with_existing_model_key_syncs(self, tmp_path: Path):
-        """Dbp init test.table1 should sync, not scaffold, when model exists."""
+    def test_init_with_existing_model_key_fails(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _create_lock(repo / "dbport.lock", _EXISTING_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "test.table1",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+        assert "model sync" in result.output
 
-        with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--project", str(repo),
-                "init", "test.table1",
-            ])
-        assert result.exit_code == 0, result.output
-        assert "Synced" in result.output
-        assert "Created model" not in result.output
-
-    def test_init_with_agency_dataset_syncs_existing(self, tmp_path: Path):
-        """Dbp init --agency test --dataset table1 should sync when model exists."""
+    def test_init_with_agency_dataset_fails_for_existing_model(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
         _create_lock(repo / "dbport.lock", _EXISTING_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
-
-        with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--project", str(repo),
-                "init", "--agency", "test", "--dataset", "table1",
-            ])
-        assert result.exit_code == 0, result.output
-        assert "Synced" in result.output
-        assert "Created model" not in result.output
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "--agency",
+                "test",
+                "--dataset",
+                "table1",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "already exists" in result.output
 
     def test_init_with_unknown_name_scaffolds(self, tmp_path: Path):
         """Dbp init brand_new should scaffold when name not in lock."""
         repo = _setup_repo(tmp_path)
         _create_lock(repo / "dbport.lock", _EXISTING_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "brand_new",
-            "--path", str(repo / "brand_new"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "brand_new",
+                "--path",
+                str(repo / "brand_new"),
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Created model" in result.output
 
@@ -431,100 +601,33 @@ class TestInitSyncExistingModel:
         """Dbp init --agency new --dataset thing should scaffold."""
         repo = _setup_repo(tmp_path)
         _create_lock(repo / "dbport.lock", _EXISTING_LOCK)
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init", "--agency", "new", "--dataset", "thing",
-            "--path", str(repo / "new_thing"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
+                "init",
+                "--agency",
+                "new",
+                "--dataset",
+                "thing",
+                "--path",
+                str(repo / "new_thing"),
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert "Created model" in result.output
 
-    def test_init_no_args_syncs_all(self, tmp_path: Path):
-        """Dbp init with no args should sync all models."""
+    def test_init_no_args_fails(self, tmp_path: Path):
         repo = _setup_repo(tmp_path)
-        _create_lock(repo / "dbport.lock", _TWO_MODELS_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        (repo / "examples" / "other").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
-
-        with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--project", str(repo),
+        result = runner.invoke(
+            app,
+            [
+                "--project",
+                str(repo),
                 "init",
-            ])
-        assert result.exit_code == 0, result.output
-        assert "Synced 2/2" in result.output
-
-    def test_init_no_args_empty_lock_fails(self, tmp_path: Path):
-        """Dbp init with no args and no models should error."""
-        repo = _setup_repo(tmp_path)
-        _create_lock(repo / "dbport.lock", "# empty lock\n")
-        result = runner.invoke(app, [
-            "--project", str(repo),
-            "init",
-        ])
+            ],
+        )
         assert result.exit_code != 0
-        assert "No models found" in result.output
-
-    def test_init_no_args_sync_failure_counted(self, tmp_path: Path):
-        """Sync failure for one model should not crash the whole sync."""
-        repo = _setup_repo(tmp_path)
-        _create_lock(repo / "dbport.lock", _TWO_MODELS_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        (repo / "examples" / "other").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
-        call_count = 0
-
-        def _side_effect(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise RuntimeError("sync failed")
-            return mp
-
-        with patch(_PATCH_TARGET, side_effect=_side_effect):
-            result = runner.invoke(app, [
-                "--project", str(repo),
-                "init",
-            ])
-        assert result.exit_code == 0, result.output
-        assert "Synced 1/2" in result.output
-
-    def test_init_no_args_json_output(self, tmp_path: Path):
-        """Dbp init with --json syncing all models."""
-        import json
-        repo = _setup_repo(tmp_path)
-        _create_lock(repo / "dbport.lock", _TWO_MODELS_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        (repo / "examples" / "other").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
-
-        with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--project", str(repo),
-                "init",
-            ])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["ok"] is True
-        assert data["data"]["total"] == 2
-
-    def test_init_single_model_json_output(self, tmp_path: Path):
-        """JSON output for single model sync."""
-        import json
-        repo = _setup_repo(tmp_path)
-        _create_lock(repo / "dbport.lock", _EXISTING_LOCK)
-        (repo / "examples" / "minimal").mkdir(parents=True, exist_ok=True)
-        mp = _mock_dbport()
-
-        with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--project", str(repo),
-                "init", "test.table1",
-            ])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data["ok"] is True
-        assert "test.table1" in data["data"]["synced"]
+        assert "No model name specified" in result.output
+        assert "project sync" in result.output

--- a/tests/test_dbport/cli/test_load.py
+++ b/tests/test_dbport/cli/test_load.py
@@ -1,14 +1,17 @@
-"""Tests for dbp load command."""
+"""Tests for dbp config model input command."""
 
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+from dbport.adapters.secondary.lock.toml import TomlLockAdapter
 from dbport.cli.main import app
+from dbport.domain.entities.input import IngestRecord
 
 runner = CliRunner()
 
@@ -20,84 +23,191 @@ def _create_lock(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-_MODEL_LOCK = '''
+_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-'''
+"""
 
 
 class TestLoadCommand:
-    def test_load_no_model_fails(self, tmp_path: Path):
+    def test_input_show_no_model_fails(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# empty\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "load", "estat.table",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "input",
+            ],
+        )
         assert result.exit_code != 0
-        assert "No models found" in result.output
+        assert "Model 'a.b' not found" in result.output
 
-    def test_load_no_args_no_inputs(self, tmp_path: Path):
+    def test_input_show_no_inputs(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
 
-        mock_port = MagicMock()
-        mock_port.__enter__ = MagicMock(return_value=mock_port)
-        mock_port.__exit__ = MagicMock(return_value=False)
-
-        with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "input",
+            ],
+        )
         assert result.exit_code == 0
-        assert "No inputs" in result.output or "Warning" in result.output
+        assert "No inputs configured" in result.output
 
-    def test_load_single_dataset(self, tmp_path: Path):
+    def test_input_add_configures_only_by_default(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
 
         mock_port = MagicMock()
         mock_port.__enter__ = MagicMock(return_value=mock_port)
         mock_port.__exit__ = MagicMock(return_value=False)
+        resolved = IngestRecord(
+            table_address="estat.table1",
+            last_snapshot_id=123,
+            last_snapshot_timestamp_ms=456,
+            rows_loaded=789,
+            version="2026-03-14",
+        )
 
-        with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load", "estat.table1",
-            ])
+        def _configure_input(*args, **kwargs):
+            TomlLockAdapter(
+                lock, model_key="a.b", model_root=".", duckdb_path="data/b.duckdb"
+            ).write_ingest_record(resolved)
+            return resolved
+
+        mock_port.configure_input.side_effect = _configure_input
+
+        with patch(_PATCH_TARGET, return_value=mock_port) as mock_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "estat.table1",
+                ],
+            )
         assert result.exit_code == 0
-        assert "Loaded estat.table1" in result.output
-        mock_port.load.assert_called_once_with("estat.table1")
+        assert "Configured input estat.table1" in result.output
+        mock_port.configure_input.assert_called_once_with(
+            "estat.table1",
+            filters=None,
+            version=None,
+        )
+        _, kwargs = mock_cls.call_args
+        assert kwargs["load_inputs_on_init"] is False
+        doc = tomllib.loads(lock.read_text())
+        item = doc["models"]["a.b"]["inputs"][0]
+        assert item["table_address"] == "estat.table1"
+        assert item["version"] == "2026-03-14"
+        assert item["last_snapshot_id"] == 123
+        assert item["rows_loaded"] == 789
 
-    def test_load_single_dataset_json(self, tmp_path: Path):
+    def test_input_add_and_load_with_flag(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
 
         mock_port = MagicMock()
         mock_port.__enter__ = MagicMock(return_value=mock_port)
         mock_port.__exit__ = MagicMock(return_value=False)
+        resolved = IngestRecord(
+            table_address="estat.table1",
+            last_snapshot_id=123,
+            last_snapshot_timestamp_ms=456,
+            rows_loaded=789,
+            version="2026-03-14",
+        )
+        mock_port.load.return_value = resolved
+
+        with patch(_PATCH_TARGET, return_value=mock_port) as mock_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "estat.table1",
+                    "--load",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Configured and loaded input estat.table1" in result.output
+        mock_port.load.assert_called_once_with("estat.table1", filters=None, version=None)
+        _, kwargs = mock_cls.call_args
+        assert kwargs["load_inputs_on_init"] is False
+
+    def test_input_add_json(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+
+        mock_port = MagicMock()
+        mock_port.__enter__ = MagicMock(return_value=mock_port)
+        mock_port.__exit__ = MagicMock(return_value=False)
+        resolved = IngestRecord(
+            table_address="estat.table1",
+            last_snapshot_id=123,
+            last_snapshot_timestamp_ms=456,
+            rows_loaded=789,
+            version="2026-03-14",
+        )
+        mock_port.configure_input.return_value = resolved
 
         with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load", "estat.table1",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "estat.table1",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
-        assert data["data"]["loaded"] == ["estat.table1"]
+        assert data["data"]["table_address"] == "estat.table1"
+        assert data["data"]["version"] == "2026-03-14"
+        assert data["data"]["last_snapshot_id"] == 123
+        assert data["data"]["rows_loaded"] == 789
+        assert data["data"]["load"] is False
 
-    def test_load_all_configured_inputs(self, tmp_path: Path):
+    def test_input_show_existing_inputs(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -109,56 +219,165 @@ table_address = "ns.tbl1"
 
 [[models."a.b".inputs]]
 table_address = "ns.tbl2"
-''')
-
-        mock_port = MagicMock()
-        mock_port.__enter__ = MagicMock(return_value=mock_port)
-        mock_port.__exit__ = MagicMock(return_value=False)
-
-        with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
-        assert result.exit_code == 0
-        assert "2 input(s)" in result.output
-        assert mock_port.load.call_count == 2
-
-    def test_load_all_inputs_with_filters(self, tmp_path: Path):
-        lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
-[models."a.b"]
-agency = "a"
-dataset_id = "b"
-model_root = "."
-duckdb_path = "data/b.duckdb"
-
-[[models."a.b".inputs]]
-table_address = "ns.tbl1"
-
-[models."a.b".inputs.filters]
-wstatus = "EMP"
-''')
-
-        mock_port = MagicMock()
-        mock_port.__enter__ = MagicMock(return_value=mock_port)
-        mock_port.__exit__ = MagicMock(return_value=False)
-
-        with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
-        assert result.exit_code == 0
-        mock_port.load.assert_called_once_with(
-            "ns.tbl1", filters={"wstatus": "EMP"}, version=None
+""",
         )
 
-    def test_load_all_json_output(self, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "input",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "ns.tbl1" in result.output
+        assert "ns.tbl2" in result.output
+
+    def test_input_add_with_filters_and_version_load(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(lock, _MODEL_LOCK)
+
+        mock_port = MagicMock()
+        mock_port.__enter__ = MagicMock(return_value=mock_port)
+        mock_port.__exit__ = MagicMock(return_value=False)
+        resolved = IngestRecord(
+            table_address="ns.tbl1",
+            last_snapshot_id=321,
+            last_snapshot_timestamp_ms=654,
+            rows_loaded=987,
+            filters={"wstatus": "EMP"},
+            version="2026-03-01",
+        )
+
+        def _load(*args, **kwargs):
+            TomlLockAdapter(
+                lock, model_key="a.b", model_root=".", duckdb_path="data/b.duckdb"
+            ).write_ingest_record(resolved)
+            return resolved
+
+        mock_port.load.side_effect = _load
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "ns.tbl1",
+                    "--filter",
+                    "wstatus=EMP",
+                    "--version",
+                    "2026-03-01",
+                    "--load",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_port.load.assert_called_once_with(
+            "ns.tbl1",
+            filters={"wstatus": "EMP"},
+            version="2026-03-01",
+        )
+        doc = tomllib.loads(lock.read_text())
+        item = doc["models"]["a.b"]["inputs"][0]
+        assert item["table_address"] == "ns.tbl1"
+        assert item["filters"]["wstatus"] == "EMP"
+        assert item["version"] == "2026-03-01"
+        assert item["last_snapshot_id"] == 321
+        assert item["rows_loaded"] == 987
+
+    def test_input_add_without_version_persists_latest_resolved_version(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+
+        mock_port = MagicMock()
+        mock_port.__enter__ = MagicMock(return_value=mock_port)
+        mock_port.__exit__ = MagicMock(return_value=False)
+        resolved = IngestRecord(
+            table_address="test.table1",
+            last_snapshot_id=8351008129908343306,
+            last_snapshot_timestamp_ms=1773050000000,
+            rows_loaded=1485615,
+            version="2026-03-14",
+        )
+
+        def _configure_input(*args, **kwargs):
+            TomlLockAdapter(
+                lock, model_key="a.b", model_root=".", duckdb_path="data/b.duckdb"
+            ).write_ingest_record(resolved)
+            return resolved
+
+        mock_port.configure_input.side_effect = _configure_input
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "test.table1",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        doc = tomllib.loads(lock.read_text())
+        item = doc["models"]["a.b"]["inputs"][0]
+        assert item["version"] == "2026-03-14"
+        assert item["last_snapshot_id"] == 8351008129908343306
+        assert item["rows_loaded"] == 1485615
+
+    def test_input_add_invalid_version_from_warehouse_fails(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+
+        mock_port = MagicMock()
+        mock_port.__enter__ = MagicMock(return_value=mock_port)
+        mock_port.__exit__ = MagicMock(return_value=False)
+        mock_port.configure_input.side_effect = ValueError("Version '2026-03-15' not found")
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "input",
+                    "test.table1",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "2026-03-15" in result.output
+
+    def test_model_load_uses_configured_inputs(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -167,58 +386,152 @@ duckdb_path = "data/b.duckdb"
 
 [[models."a.b".inputs]]
 table_address = "ns.tbl1"
-''')
+filters = { wstatus = "EMP" }
+version = "2026-03-01"
+""",
+        )
+
+        mock_port = MagicMock()
+        mock_port.__enter__ = MagicMock(return_value=mock_port)
+        mock_port.__exit__ = MagicMock(return_value=False)
+
+        with patch(_PATCH_TARGET, return_value=mock_port) as mock_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "load",
+                    "a.b",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Loaded 1 input(s) for a.b" in result.output
+        mock_port.load.assert_called_once_with(
+            "ns.tbl1",
+            filters={"wstatus": "EMP"},
+            version="2026-03-01",
+        )
+        _, kwargs = mock_cls.call_args
+        assert kwargs["load_inputs_on_init"] is False
+
+    def test_model_load_update_uses_latest_snapshot(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(
+            lock,
+            """
+[models."a.b"]
+agency = "a"
+dataset_id = "b"
+model_root = "."
+duckdb_path = "data/b.duckdb"
+
+[[models."a.b".inputs]]
+table_address = "ns.tbl1"
+version = "2026-03-01"
+""",
+        )
 
         mock_port = MagicMock()
         mock_port.__enter__ = MagicMock(return_value=mock_port)
         mock_port.__exit__ = MagicMock(return_value=False)
 
         with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "load",
+                    "a.b",
+                    "--update",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Updated 1 input(s) for a.b" in result.output
+        mock_port.load.assert_called_once_with("ns.tbl1", filters=None, version=None)
+
+    def test_input_show_json(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(
+            lock,
+            """
+[models."a.b"]
+agency = "a"
+dataset_id = "b"
+model_root = "."
+duckdb_path = "data/b.duckdb"
+
+[[models."a.b".inputs]]
+table_address = "ns.tbl1"
+""",
+        )
+
+        result = runner.invoke(
+            app,
+            [
                 "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "input",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["data"]["loaded"] == ["ns.tbl1"]
+        assert data["data"]["inputs"][0]["table_address"] == "ns.tbl1"
 
-    def test_load_no_inputs_json(self, tmp_path: Path):
+    def test_input_show_no_inputs_json(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
 
-        mock_port = MagicMock()
-        mock_port.__enter__ = MagicMock(return_value=mock_port)
-        mock_port.__exit__ = MagicMock(return_value=False)
-
-        with patch(_PATCH_TARGET, return_value=mock_port):
-            result = runner.invoke(app, [
+        result = runner.invoke(
+            app,
+            [
                 "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "input",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["data"]["loaded"] == []
+        assert data["data"]["inputs"] == []
 
-    def test_load_no_args_models_gone_after_resolve(self, tmp_path: Path):
-        """Cover load.py line 47: models exist for resolve but gone on re-read."""
+    def test_input_invalid_filter_fails(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
 
-        mock_port = MagicMock()
-        mock_port.__enter__ = MagicMock(return_value=mock_port)
-        mock_port.__exit__ = MagicMock(return_value=False)
-
-        # After DBPort init succeeds, read_lock_models returns empty
-        with patch(_PATCH_TARGET, return_value=mock_port), \
-             patch("dbport.cli.commands.load.read_lock_models", return_value={}):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "load",
-            ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "input",
+                "ns.tbl1",
+                "--filter",
+                "badfilter",
+            ],
+        )
         assert result.exit_code != 0
-        assert "No models" in result.output
+        assert "Expected key=value" in result.output

--- a/tests/test_dbport/cli/test_main.py
+++ b/tests/test_dbport/cli/test_main.py
@@ -13,11 +13,9 @@ class TestAppHelp:
         assert result.exit_code == 0
         assert "init" in result.output
         assert "status" in result.output
-        assert "check" in result.output
-        assert "schema" in result.output
-        assert "load" in result.output
-        assert "run" in result.output
-        assert "publish" in result.output
+        assert "model" in result.output
+        assert "project" in result.output
+        assert "config" in result.output
 
     def test_no_args_shows_help(self):
         result = runner.invoke(app, [])
@@ -48,22 +46,59 @@ class TestAppHelp:
         result = runner.invoke(app, ["config", "--help"])
         assert result.exit_code == 0
         assert "default" in result.output
-        assert "info" in result.output
+        assert "model" in result.output
+
+    def test_config_model_help(self):
+        result = runner.invoke(app, ["config", "model", "a.b", "--help"])
+        assert result.exit_code == 0
+        assert "schema" in result.output
+        assert "version" in result.output
+        assert "columns" in result.output
+        assert "input" in result.output
+
+    def test_model_help(self):
+        result = runner.invoke(app, ["model", "--help"])
+        assert result.exit_code == 0
+        assert "sync" in result.output
+        assert "load" in result.output
+        assert "exec" in result.output
+        assert "publish" in result.output
+        assert "run" in result.output
+
+    def test_project_help(self):
+        result = runner.invoke(app, ["project", "--help"])
+        assert result.exit_code == 0
+        assert "sync" in result.output
+        assert "load" in result.output
+        assert "exec" in result.output
+        assert "publish" in result.output
+        assert "run" in result.output
+
+    def test_status_help(self):
+        result = runner.invoke(app, ["status", "--help"])
+        assert result.exit_code == 0
+        assert "check" in result.output
 
     def test_no_color_flag(self, tmp_path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# ok\n")
-        result = runner.invoke(app, [
-            "--no-color",
-            "--lockfile", str(lock),
-            "check",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--no-color",
+                "--lockfile",
+                str(lock),
+                "status",
+                "check",
+            ],
+        )
         assert result.exit_code == 0
 
 
 class TestCliEntrypoint:
     def test_main_function_importable(self):
         from dbport.cli import main
+
         assert callable(main)
 
     def test_main_invokes_app(self):

--- a/tests/test_dbport/cli/test_project.py
+++ b/tests/test_dbport/cli/test_project.py
@@ -1,0 +1,345 @@
+"""Tests for dbp project lifecycle commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+import dbport.cli.commands.project as project_commands
+from dbport.cli.main import app
+
+runner = CliRunner()
+
+_PATCH_TARGET = "dbport.adapters.primary.client.DBPort"
+
+
+_MULTI_MODEL_LOCK = """
+[models."a.b"]
+agency = "a"
+dataset_id = "b"
+model_root = "."
+duckdb_path = "data/b.duckdb"
+run_hook = "main.py"
+version = "2026-03-15"
+
+[[models."a.b".versions]]
+version = "2026-03-15"
+completed = true
+
+[models."c.d"]
+agency = "c"
+dataset_id = "d"
+model_root = "models/d"
+duckdb_path = "models/d/data/d.duckdb"
+run_hook = "main.py"
+version = "2026-03-16"
+
+[[models."c.d".versions]]
+version = "2026-03-16"
+completed = true
+"""
+
+
+_DEPENDENT_MODEL_LOCK = (
+    _MULTI_MODEL_LOCK
+    + """
+
+[[models."c.d".inputs]]
+table_address = "a.b"
+version = "2026-03-15"
+"""
+)
+
+
+def _create_lock(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _mock_port() -> MagicMock:
+    mock_port = MagicMock()
+    mock_port.__enter__ = MagicMock(return_value=mock_port)
+    mock_port.__exit__ = MagicMock(return_value=False)
+    mock_port.run_hook = "main.py"
+    mock_port._dataset = type("D", (), {"model_root": "."})()
+    return mock_port
+
+
+class TestProjectCommands:
+    def test_project_help(self):
+        result = runner.invoke(app, ["project", "--help"])
+        assert result.exit_code == 0
+        assert "sync" in result.output
+        assert "load" in result.output
+        assert "exec" in result.output
+        assert "publish" in result.output
+        assert "run" in result.output
+
+    def test_project_sync_runs_all_models(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MULTI_MODEL_LOCK)
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port) as mock_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "sync",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Synced 2 model(s)" in result.output
+        assert mock_cls.call_count == 2
+
+    def test_project_load_runs_all_models(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(
+            lock,
+            _MULTI_MODEL_LOCK
+            + """
+
+[[models."a.b".inputs]]
+table_address = "ns.tbl1"
+version = "2026-03-01"
+
+[[models."c.d".inputs]]
+table_address = "ns.tbl2"
+filters = { geo = "DE" }
+""",
+        )
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port) as mock_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "load",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Loaded inputs for 2 model(s)" in result.output
+        assert mock_cls.call_count == 2
+        mock_port.load.assert_any_call("ns.tbl1", filters=None, version="2026-03-01")
+        mock_port.load.assert_any_call("ns.tbl2", filters={"geo": "DE"}, version=None)
+        _, kwargs = mock_cls.call_args
+        assert kwargs["load_inputs_on_init"] is False
+
+    def test_project_load_update_uses_latest_snapshot(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(
+            lock,
+            _MULTI_MODEL_LOCK
+            + """
+
+[[models."a.b".inputs]]
+table_address = "ns.tbl1"
+version = "2026-03-01"
+
+[[models."c.d".inputs]]
+table_address = "ns.tbl2"
+version = "2026-03-02"
+""",
+        )
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "load",
+                    "--update",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Updated inputs for 2 model(s)" in result.output
+        assert mock_port.load.call_count == 2
+        for call in mock_port.load.call_args_list:
+            assert call.kwargs["version"] is None
+
+    def test_project_sync_uses_thread_pool(self, tmp_path: Path):
+        from concurrent.futures import Future
+
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MULTI_MODEL_LOCK)
+        mock_port = _mock_port()
+        seen_max_workers: list[int] = []
+
+        class FakeExecutor:
+            def __init__(self, *, max_workers: int):
+                seen_max_workers.append(max_workers)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def submit(self, fn, *args, **kwargs):
+                future: Future = Future()
+                try:
+                    future.set_result(fn(*args, **kwargs))
+                except Exception as exc:  # pragma: no cover - defensive
+                    future.set_exception(exc)
+                return future
+
+        with (
+            patch(_PATCH_TARGET, return_value=mock_port),
+            patch.object(project_commands, "ThreadPoolExecutor", FakeExecutor),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "sync",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert seen_max_workers == [2]
+
+    def test_project_exec_batches_internal_dependencies(self, tmp_path: Path):
+        from concurrent.futures import Future
+
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _DEPENDENT_MODEL_LOCK)
+        mock_port = _mock_port()
+        seen_max_workers: list[int] = []
+
+        class FakeExecutor:
+            def __init__(self, *, max_workers: int):
+                seen_max_workers.append(max_workers)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def submit(self, fn, *args, **kwargs):
+                future: Future = Future()
+                try:
+                    future.set_result(fn(*args, **kwargs))
+                except Exception as exc:  # pragma: no cover - defensive
+                    future.set_exception(exc)
+                return future
+
+        with (
+            patch(_PATCH_TARGET, return_value=mock_port) as mock_cls,
+            patch.object(project_commands, "ThreadPoolExecutor", FakeExecutor),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "exec",
+                    "--target",
+                    "sql/transform.sql",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert seen_max_workers == [1, 1]
+        dataset_ids = [call.kwargs["dataset_id"] for call in mock_cls.call_args_list]
+        assert dataset_ids == ["b", "d"]
+
+    def test_project_exec_uses_target_override(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MULTI_MODEL_LOCK)
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "exec",
+                    "--target",
+                    "sql/transform.sql",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Executed 2 model(s)" in result.output
+        assert mock_port.execute.call_count == 2
+        mock_port.execute.assert_any_call("sql/transform.sql")
+
+    def test_project_publish_json(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MULTI_MODEL_LOCK)
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "publish",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["data"]["total"] == 2
+        assert len(data["data"]["results"]) == 2
+        assert all(item["mode"] == "dry" for item in data["data"]["results"])
+
+    def test_project_run_json(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MULTI_MODEL_LOCK)
+        mock_port = _mock_port()
+
+        with patch(_PATCH_TARGET, return_value=mock_port):
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "project",
+                    "run",
+                    "--target",
+                    "sql/main.sql",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["data"]["total"] == 2
+        assert all(item["target"] == "sql/main.sql" for item in data["data"]["results"])
+        assert all(item["mode"] == "dry" for item in data["data"]["results"])

--- a/tests/test_dbport/cli/test_publish.py
+++ b/tests/test_dbport/cli/test_publish.py
@@ -1,4 +1,4 @@
-"""Tests for dbp publish command."""
+"""Tests for dbp model publish command."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ def _create_lock(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-_MODEL_LOCK = '''
+_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -30,17 +30,17 @@ duckdb_path = "data/b.duckdb"
 [[models."a.b".versions]]
 version = "2026-03-15"
 completed = true
-'''
+"""
 
-_MODEL_LOCK_NO_VERSIONS = '''
+_MODEL_LOCK_NO_VERSIONS = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-'''
+"""
 
-_MULTI_MODEL_LOCK = '''
+_MULTI_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -60,7 +60,7 @@ duckdb_path = "models/d/data/d.duckdb"
 [[models."c.d".versions]]
 version = "2026-03-15"
 completed = true
-'''
+"""
 
 
 def _mock_port():
@@ -72,7 +72,7 @@ def _mock_port():
 
 class TestPublishCommand:
     def test_publish_help(self):
-        result = runner.invoke(app, ["publish", "--help"])
+        result = runner.invoke(app, ["model", "publish", "--help"])
         assert result.exit_code == 0
         assert "--version" in result.output
         assert "--dry-run" in result.output
@@ -85,11 +85,17 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                ],
+            )
         assert result.exit_code != 0
         assert "No completed versions" in result.output
 
@@ -100,21 +106,34 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                ],
+            )
         assert result.exit_code == 0
         mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_publish_no_model_fails(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# empty\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "publish", "--version", "2026-01-01",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "model",
+                "publish",
+                "--version",
+                "2026-01-01",
+            ],
+        )
         assert result.exit_code != 0
 
     def test_publish_success(self, tmp_path: Path):
@@ -123,11 +142,19 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
         assert result.exit_code == 0
         assert "Published version 2026-03-15" in result.output
         mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
@@ -138,11 +165,20 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15", "--dry-run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                    "--dry-run",
+                ],
+            )
         assert result.exit_code == 0
         assert "Dry run completed" in result.output
         mp.publish.assert_called_once_with(version="2026-03-15", mode="dry")
@@ -153,11 +189,20 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15", "--refresh",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                    "--refresh",
+                ],
+            )
         assert result.exit_code == 0
         assert "Published version 2026-03-15" in result.output
         mp.publish.assert_called_once_with(version="2026-03-15", mode="refresh")
@@ -169,11 +214,18 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--refresh",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--refresh",
+                ],
+            )
         assert result.exit_code == 0
         mp.publish.assert_called_once_with(version="2026-03-15", mode="refresh")
 
@@ -183,11 +235,20 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp) as mock_cls:
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "c.d", "--version", "2026-03-15",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "c.d",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
         assert result.exit_code == 0
         call_kwargs = mock_cls.call_args[1]
         assert call_kwargs["agency"] == "c"
@@ -199,12 +260,21 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15",
-                "--message", "Quarterly update",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                    "--message",
+                    "Quarterly update",
+                ],
+            )
         assert result.exit_code == 0
         assert "Quarterly update" in result.output
 
@@ -214,12 +284,21 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15", "--dry-run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                    "--dry-run",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -233,10 +312,18 @@ class TestPublishCommand:
         mp = _mock_port()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "publish", "--version", "2026-03-15",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "publish",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
         assert result.exit_code == 0
         assert "a.b" in result.output

--- a/tests/test_dbport/cli/test_render.py
+++ b/tests/test_dbport/cli/test_render.py
@@ -8,6 +8,7 @@ from io import StringIO
 from rich.console import Console
 
 from dbport.cli.render import (
+    cli_tree_progress,
     get_console,
     get_stdout,
     print_error,
@@ -19,6 +20,7 @@ from dbport.cli.render import (
     print_warning,
     set_no_color,
 )
+from dbport.infrastructure.progress import progress_callback, progress_phase
 
 
 class TestRenderHelpers:
@@ -118,3 +120,48 @@ class TestRenderHelpers:
         finally:
             _mod._stdout = old
         assert "some info" in buf.getvalue()
+
+    def test_cli_tree_progress_shows_fixed_run_phases(self):
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, force_terminal=False, width=120)
+        import dbport.cli.render as _mod
+
+        old = _mod._console
+        _mod._console = console
+        try:
+            with cli_tree_progress(enabled=True, title="Running models") as model_ctx:
+                with model_ctx("a.b"):
+                    with progress_phase("sync", title="Sync", icon="🔄"):
+                        cb = progress_callback.get()
+                        assert cb is not None
+                        cb.started("Detecting schema from warehouse")
+                        cb.finished("No existing warehouse table")
+
+                    with progress_phase("load", title="Load", icon="📥"):
+                        cb = progress_callback.get()
+                        assert cb is not None
+                        cb.log("Skipping ns.tbl (snapshot unchanged)")
+
+                    with progress_phase("exec", title="Exec", icon="⚙️"):
+                        cb = progress_callback.get()
+                        assert cb is not None
+                        cb.started("Executing main.py")
+                        cb.finished("Executed main.py")
+
+                    with progress_phase("publish", title="Publish", icon="🚀"):
+                        cb = progress_callback.get()
+                        assert cb is not None
+                        cb.started("Publishing a.b", total=10)
+                        cb.update(5)
+                        cb.finished("Published a.b")
+        finally:
+            _mod._console = old
+
+        output = buf.getvalue()
+        assert "🔄 Sync" in output
+        assert "📥 Load" in output
+        assert "⚙️ Exec" in output
+        assert "🚀 Publish" in output
+        assert "No existing warehouse table" in output
+        assert "Skipping ns.tbl (snapshot unchanged)" in output
+        assert "Published a.b" in output

--- a/tests/test_dbport/cli/test_run.py
+++ b/tests/test_dbport/cli/test_run.py
@@ -1,4 +1,4 @@
-"""Tests for dbp run command (full workflow: sync, execute, publish)."""
+"""Tests for dbp model run command."""
 
 from __future__ import annotations
 
@@ -20,41 +20,41 @@ def _create_lock(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-_MODEL_LOCK = '''
+_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-run_hook = "sql/main.sql"
+run_hook = "main.py"
 version = "2026-03-15"
-'''
+"""
 
-_MODEL_LOCK_NO_HOOK = '''
+_MODEL_LOCK_NO_HOOK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
 version = "2026-03-15"
-'''
+"""
 
-_MODEL_LOCK_NO_VERSION = '''
+_MODEL_LOCK_NO_VERSION = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-run_hook = "sql/main.sql"
-'''
+run_hook = "main.py"
+"""
 
-_MULTI_MODEL_LOCK = '''
+_MULTI_MODEL_LOCK = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-run_hook = "sql/main.sql"
+run_hook = "main.py"
 version = "2026-03-15"
 
 [models."c.d"]
@@ -64,15 +64,15 @@ model_root = "models/d"
 duckdb_path = "models/d/data/d.duckdb"
 run_hook = "sql/run.sql"
 version = "2026-03-15"
-'''
+"""
 
-_MODEL_LOCK_WITH_VERSIONS = '''
+_MODEL_LOCK_WITH_VERSIONS = """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-run_hook = "sql/main.sql"
+run_hook = "main.py"
 
 [[models."a.b".versions]]
 version = "2026-03-14"
@@ -81,36 +81,42 @@ completed = true
 [[models."a.b".versions]]
 version = "2026-03-15"
 completed = true
-'''
+"""
 
 
-def _mock_dbport(run_hook="sql/main.sql"):
+def _mock_dbport(run_hook="main.py"):
     mock_port = MagicMock()
     mock_port.__enter__ = MagicMock(return_value=mock_port)
     mock_port.__exit__ = MagicMock(return_value=False)
     mock_port.run_hook = run_hook
-    if run_hook is None:
-        mock_port.run.side_effect = RuntimeError(
-            "No run_hook configured for this model. "
-            "Set it with: dbp config run-hook <path>"
-        )
+    mock_port._dataset = type("D", (), {"model_root": "."})()
     return mock_port
 
 
 class TestRunCommand:
-    def test_run_no_hook_fails(self, tmp_path: Path):
+    def test_run_no_hook_defaults_to_main_py(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK_NO_HOOK)
-        mp = _mock_dbport(run_hook=None)
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp = _mock_dbport(run_hook="main.py")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
-        assert result.exit_code != 0
-        assert "No run_hook configured" in result.output
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "main.py" in result.output
+        mp.execute.assert_called_once_with("SELECT 1")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_run_no_version_fails(self, tmp_path: Path):
         """When no version is configured or in history, run fails early."""
@@ -119,34 +125,81 @@ class TestRunCommand:
         mp = _mock_dbport()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
         assert result.exit_code != 0
         assert "No version available" in result.output
+        assert "dbp config model a.b" in result.output
+        assert "version" in result.output
+        assert "<version>" in result.output
 
     def test_run_help(self):
-        result = runner.invoke(app, ["run", "--help"])
+        result = runner.invoke(app, ["model", "run", "--help"])
         assert result.exit_code == 0
-        assert "workflow" in result.output.lower()
+        assert "publish" in result.output.lower()
+        assert "--target" in result.output
 
     def test_run_success(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
         assert result.exit_code == 0
         assert "Executed" in result.output
-        # Auto-resolves version from config
-        mp.run.assert_called_once_with(version="2026-03-15", mode=None)
+        mp.execute.assert_called_once_with("SELECT 1")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
+
+    def test_run_python_hook_callable_uses_injected_port(self, tmp_path: Path):
+        lock = tmp_path / "dbport.lock"
+        _create_lock(lock, _MODEL_LOCK)
+        mp = _mock_dbport()
+        (tmp_path / "main.py").write_text(
+            "def run(port):\n"
+            "    port.execute('SELECT 2')\n\n"
+            "if __name__ == '__main__':\n"
+            "    raise RuntimeError('should not execute standalone block')\n",
+            encoding="utf-8",
+        )
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
+
+        with patch(_PATCH_TARGET, return_value=mp):
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mp.execute.assert_called_once_with("SELECT 2")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_run_with_model_positional_arg(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
@@ -154,11 +207,18 @@ class TestRunCommand:
         mp = _mock_dbport(run_hook="sql/run.sql")
 
         with patch(_PATCH_TARGET, return_value=mp) as mock_cls:
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "c.d",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "c.d",
+                ],
+            )
         assert result.exit_code == 0
         # Verify DBPort was called with the correct model
         call_kwargs = mock_cls.call_args[1]
@@ -169,27 +229,46 @@ class TestRunCommand:
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--version", "2026-03-15",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode=None)
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_run_with_timing(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--timing",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--timing",
+                ],
+            )
         assert result.exit_code == 0
         assert "Duration" in result.output
 
@@ -197,28 +276,41 @@ class TestRunCommand:
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
-        assert data["data"]["run_hook"] == "sql/main.sql"
+        assert data["data"]["target"] == "main.py"
         assert data["data"]["model"] == "a.b"
         assert "elapsed_seconds" in data["data"]
 
     def test_run_no_model_fails(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# empty\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "run",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "model",
+                "run",
+            ],
+        )
         assert result.exit_code != 0
         assert "No models found" in result.output
 
@@ -226,56 +318,97 @@ class TestRunCommand:
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--version", "2026-03-15", "--dry-run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--version",
+                    "2026-03-15",
+                    "--dry-run",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode="dry")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode="dry")
 
     def test_run_refresh_mode(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--version", "2026-03-15", "--refresh",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--version",
+                    "2026-03-15",
+                    "--refresh",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode="refresh")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode="refresh")
 
     def test_run_refresh_without_version_uses_latest(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK_WITH_VERSIONS)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--refresh",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--refresh",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode="refresh")
+        mp.publish.assert_called_once_with(version="2026-03-15", mode="refresh")
 
     def test_run_json_output_with_version(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--version", "2026-03-15",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--version",
+                    "2026-03-15",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -287,12 +420,19 @@ class TestRunCommand:
         mp = _mock_dbport(run_hook="sql/run.sql")
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "c.d",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "c.d",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["model"] == "c.d"
@@ -302,42 +442,68 @@ class TestRunCommand:
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode=None)
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_run_falls_back_to_latest_completed_version(self, tmp_path: Path):
         """Without config version, falls back to latest completed version."""
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK_WITH_VERSIONS)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-03-15", mode=None)
+        mp.publish.assert_called_once_with(version="2026-03-15", mode=None)
 
     def test_run_explicit_version_overrides_config(self, tmp_path: Path):
         """--version flag takes precedence over config version."""
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, _MODEL_LOCK)
         mp = _mock_dbport()
+        (tmp_path / "main.py").write_text("port.execute('SELECT 1')", encoding="utf-8")
+        mp._dataset = type("D", (), {"model_root": str(tmp_path)})()
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "run", "--version", "2026-04-01",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "model",
+                    "run",
+                    "--version",
+                    "2026-04-01",
+                ],
+            )
         assert result.exit_code == 0
-        mp.run.assert_called_once_with(version="2026-04-01", mode=None)
+        mp.publish.assert_called_once_with(version="2026-04-01", mode=None)

--- a/tests/test_dbport/cli/test_schema.py
+++ b/tests/test_dbport/cli/test_schema.py
@@ -1,4 +1,4 @@
-"""Tests for dbp schema command."""
+"""Tests for dbp config model <model> schema command."""
 
 from __future__ import annotations
 
@@ -24,30 +24,49 @@ class TestSchemaShowCommand:
     def test_schema_show_no_model(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         lock.write_text("# empty\n")
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "schema",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         assert "No models found" in result.output
 
     def test_schema_show_no_ddl(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
-''')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "schema",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         assert "No schema defined" in result.output
 
     def test_schema_show_with_columns(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -64,18 +83,28 @@ sql_type = "VARCHAR"
 column_name = "val"
 column_pos = 1
 sql_type = "DOUBLE"
-''')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "schema",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         assert "id" in result.output
         assert "VARCHAR" in result.output
 
     def test_schema_show_json(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
@@ -87,32 +116,49 @@ ddl = "CREATE TABLE a.b (id VARCHAR)"
 column_name = "id"
 column_pos = 0
 sql_type = "VARCHAR"
-''')
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "schema",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["ddl"] is not None
         assert len(data["data"]["columns"]) == 1
 
-
     def test_schema_show_no_columns(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 
 [models."a.b".schema]
 ddl = "CREATE TABLE a.b (id VARCHAR)"
-''')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "schema",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         assert "No columns defined" in result.output
         assert "DDL" in result.output
@@ -120,11 +166,18 @@ ddl = "CREATE TABLE a.b (id VARCHAR)"
     def test_schema_show_json_no_models(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
         _create_lock(lock, "# empty\n")
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "schema",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["data"]["schema"] is None
@@ -133,45 +186,71 @@ ddl = "CREATE TABLE a.b (id VARCHAR)"
 class TestSchemaApplyCommand:
     def test_schema_apply_file_not_found(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
-''')
-        result = runner.invoke(app, [
-            "--lockfile", str(lock),
-            "schema", "/nonexistent/path.sql",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--lockfile",
+                str(lock),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+                "/nonexistent/path.sql",
+            ],
+        )
         assert result.exit_code != 0
         assert "not found" in result.output
 
     def test_schema_apply_file_not_found_json(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
-''')
-        result = runner.invoke(app, [
-            "--json",
-            "--lockfile", str(lock),
-            "--project", str(tmp_path),
-            "schema", "nonexistent.sql",
-        ])
+""",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--lockfile",
+                str(lock),
+                "--project",
+                str(tmp_path),
+                "config",
+                "model",
+                "a.b",
+                "schema",
+                "nonexistent.sql",
+            ],
+        )
         assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["ok"] is False
 
     def test_schema_apply_success(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-''')
+""",
+        )
         # Create the SQL file so the pre-check passes
         sql_dir = tmp_path / "sql"
         sql_dir.mkdir()
@@ -182,24 +261,36 @@ duckdb_path = "data/b.duckdb"
         mp.__exit__ = MagicMock(return_value=False)
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "schema", "sql/create_output.sql",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "schema",
+                    "sql/create_output.sql",
+                ],
+            )
         assert result.exit_code == 0
         assert "Schema applied" in result.output
         mp.schema.assert_called_once_with("sql/create_output.sql")
 
     def test_schema_apply_json_output(self, tmp_path: Path):
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-''')
+""",
+        )
         sql_dir = tmp_path / "sql"
         sql_dir.mkdir()
         (sql_dir / "out.sql").write_text("CREATE TABLE a.b (id VARCHAR);")
@@ -209,12 +300,21 @@ duckdb_path = "data/b.duckdb"
         mp.__exit__ = MagicMock(return_value=False)
 
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--json",
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "schema", "sql/out.sql",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "schema",
+                    "sql/out.sql",
+                ],
+            )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["ok"] is True
@@ -224,23 +324,35 @@ duckdb_path = "data/b.duckdb"
     def test_schema_apply_non_sql_extension(self, tmp_path: Path):
         """Source without .sql extension skips file existence pre-check."""
         lock = tmp_path / "dbport.lock"
-        _create_lock(lock, '''
+        _create_lock(
+            lock,
+            """
 [models."a.b"]
 agency = "a"
 dataset_id = "b"
 model_root = "."
 duckdb_path = "data/b.duckdb"
-''')
+""",
+        )
         mp = MagicMock()
         mp.__enter__ = MagicMock(return_value=mp)
         mp.__exit__ = MagicMock(return_value=False)
 
         # Non-.sql source like a DDL string — no file check, passes through to port.schema()
         with patch(_PATCH_TARGET, return_value=mp):
-            result = runner.invoke(app, [
-                "--lockfile", str(lock),
-                "--project", str(tmp_path),
-                "schema", "CREATE TABLE a.b (id VARCHAR)",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "--lockfile",
+                    str(lock),
+                    "--project",
+                    str(tmp_path),
+                    "config",
+                    "model",
+                    "a.b",
+                    "schema",
+                    "CREATE TABLE a.b (id VARCHAR)",
+                ],
+            )
         assert result.exit_code == 0
         mp.schema.assert_called_once_with("CREATE TABLE a.b (id VARCHAR)")


### PR DESCRIPTION
- Updated test cases to reflect changes in CLI commands for publishing, running, and schema operations to use "model" as a subcommand.
- Changed the lock file content format from single quotes to triple double quotes for consistency.
- Modified the mock database port to use "main.py" as the default run hook instead of "sql/main.sql".
- Enhanced tests for schema commands to include model-specific configurations.
- Improved test descriptions for clarity and accuracy regarding the model context.