### PR TITLE
Document release versioning policy and fix CLI version fallback

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -159,52 +159,21 @@ Status: `done`
 
 Theme: version policy and release planning language.
 
-### DBP-VERS-005 - Document and enforce the project's release numbering policy
+Status: `done`
 
-- Priority: `P0`
-- Status: `todo`
-- Files:
-  - `docs/changelog.md`
-  - release/versioning docs
-  - packaging/release workflow
-- Required changes:
-  - Document the project's chosen `x.x.x` policy
-  - Capture the project-specific convention:
-    - first number bump = major release step
-    - second number bump = normal release step
-    - third number bump = minor release step
-  - Use that policy consistently in changelog and release docs
-- Acceptance criteria:
-  - Contributors have one clear versioning policy to follow
+### What was implemented
 
-### DBP-VERS-006 - Encode the initial release milestones in docs and release workflow
+- **Release versioning policy** — added `docs/release-versioning.md` documenting the project's `X.Y.Z` numbering convention (major / normal / minor), the predevelopment milestone path from `0.0.1` to `0.1.0`, the single source of truth in `pyproject.toml`, and a per-version release checklist
+- **CLI version fallback fixed** — removed the hard-coded `"0.1.0"` fallback in `dbp --version`; now reports `"unknown"` when `importlib.metadata` cannot resolve the package version
+- **Version surfaces documented** — `pyproject.toml` is the declared single source of truth; `dbp --version`, docs deployment, git tags, and release automation all derive from it consistently
 
-- Priority: `P1`
-- Status: `todo`
-- Files:
-  - changelog and release/versioning docs
-  - packaging/release workflow
-- Required changes:
-  - Record that predevelopment starts at `0.0.1`
-  - Record that the first version published to PyPI and GitHub Pages will be `0.1.0`
-- Acceptance criteria:
-  - The initial release path is explicitly documented
+### Items delivered
 
-### DBP-VERS-009 - Make runtime and CLI version reporting follow the declared source of truth
-
-- Priority: `P1`
-- Status: `todo`
-- Files:
-  - `pyproject.toml`
-  - `src/dbport/cli/main.py`
-  - package/version tests
-- Required changes:
-  - Make runtime-facing version reporting derive from the same package version source used by release automation
-  - Remove hard-coded fallback behavior that can report a release version unrelated to the installed package
-  - Decide whether package-level runtime version metadata is part of the supported public contract and test it accordingly
-  - Ensure `dbp --version`, package metadata, docs version labels, and release automation all describe the same version coherently
-- Acceptance criteria:
-  - Runtime and CLI version reporting are consistent with the declared package version source of truth
+| Item | Priority | Summary |
+|---|---|---|
+| DBP-VERS-005 | `P0` | Release numbering policy documented in `docs/release-versioning.md` |
+| DBP-VERS-006 | `P1` | Initial release milestones (`0.0.1` → `0.1.0`) encoded in versioning docs |
+| DBP-VERS-009 | `P1` | CLI version fallback fixed; all version surfaces derive from `pyproject.toml` |
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,21 @@ Each entry includes: version number, release date, and a summary of changes grou
 
 ---
 
+## 0.0.3 — 2026-03-17
+
+Version policy and release planning language.
+
+### Added
+
+- **Release versioning policy** — new `docs/release-versioning.md` page documenting the project's `X.Y.Z` numbering convention (major / normal / minor), the predevelopment milestone path from `0.0.1` to `0.1.0`, the single source of truth in `pyproject.toml`, and the per-version release checklist
+- **Release Versioning** added to docs site navigation
+
+### Fixed
+
+- **CLI version fallback** — `dbp --version` no longer reports a hard-coded `"0.1.0"` when package metadata is unavailable; now reports `"unknown"` instead of a misleading future version
+
+---
+
 ## 0.0.2 — 2026-03-17
 
 Release history and roadmap foundations.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -1,0 +1,76 @@
+# Release Versioning
+
+This page documents the release numbering policy for the DBPort project.
+
+---
+
+## Numbering scheme
+
+DBPort uses a three-part version number: **`X.Y.Z`**
+
+| Position | Name | Meaning |
+|---|---|---|
+| `X` | Major | Breaking changes or major release step |
+| `Y` | Normal | Feature additions or normal release step |
+| `Z` | Minor | Fixes, documentation, or small improvements |
+
+Examples:
+
+- `0.0.1` → `0.0.2`: minor release step (docs, polish, small changes)
+- `0.0.9` → `0.1.0`: normal release step (first public release)
+- `0.1.0` → `1.0.0`: major release step (would signal a breaking or significant milestone)
+
+---
+
+## Initial release path
+
+Development starts at `0.0.1` and proceeds through ten predevelopment work packages:
+
+| Version | Milestone |
+|---|---|
+| `0.0.1` | Foundation: versioning mechanism online |
+| `0.0.2` | Release history and roadmap |
+| `0.0.3` | Version policy and release planning language |
+| `0.0.4` | Python API reference correctness |
+| `0.0.5` | CLI reference and executable workflows |
+| `0.0.6` | Public package surface and repository trustworthiness |
+| `0.0.7` | Execution model and conceptual docs depth |
+| `0.0.8` | Zensical navigation model |
+| `0.0.9` | Homepage UX and publication-facing polish |
+| **`0.1.0`** | **First public release** (PyPI + GitHub Pages) |
+
+The `0.0.x` series is predevelopment. No stability guarantees apply until `0.1.0`.
+
+**`0.1.0`** is the first version published to PyPI and GitHub Pages. From that point forward, the versioning policy applies to all public releases.
+
+---
+
+## Source of truth
+
+The **single source of truth** for the package version is the `version` field in `pyproject.toml`:
+
+```toml
+[project]
+version = "0.0.3"
+```
+
+All version-bearing surfaces derive from this value:
+
+| Surface | How it reads the version |
+|---|---|
+| `dbp --version` | `importlib.metadata.version("dbport")` (reads installed package metadata, which comes from `pyproject.toml`) |
+| Docs deployment | Extracts version from `pyproject.toml` directly; validates against git tag |
+| Git tags | Must match `v{version}` (e.g., `v0.1.0` for version `0.1.0`) |
+| Release workflow | Fails if the git tag does not match `pyproject.toml` |
+
+No hard-coded version strings exist in source code. If `importlib.metadata` cannot resolve the version (e.g., broken install), the CLI reports `"unknown"` rather than guessing.
+
+---
+
+## Release checklist (per version)
+
+1. Update `version` in `pyproject.toml`
+2. Add a changelog entry in `docs/changelog.md`
+3. Update `docs/roadmap.md` status
+4. Tag the commit as `v{version}`
+5. Push the tag to trigger the docs deployment workflow

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ For completed work, see the [Changelog](changelog.md).
 |---|---|---|
 | 0.0.1 | Foundation: runtime, architecture, CLI, docs site, CI | Done |
 | 0.0.2 | Release history and roadmap foundations | Done |
-| 0.0.3 | Version policy and release planning language | Planned |
+| 0.0.3 | Version policy and release planning language | Done |
 | 0.0.4 | Python API reference correctness | Planned |
 | 0.0.5 | CLI reference and executable workflows | Planned |
 | 0.0.6 | Public package surface and repository trustworthiness | Planned |
@@ -25,9 +25,9 @@ For completed work, see the [Changelog](changelog.md).
 
 ## 0.0.3 — Version policy and release planning language
 
-- Document and enforce the project's release numbering policy
-- Encode the initial release milestones (`0.0.1` → `0.1.0`) in docs and release workflow
-- Make runtime and CLI version reporting derive from `pyproject.toml` consistently
+- ~~Document and enforce the project's release numbering policy~~
+- ~~Encode the initial release milestones (`0.0.1` → `0.1.0`) in docs and release workflow~~
+- ~~Make runtime and CLI version reporting derive from `pyproject.toml` consistently~~
 
 ## 0.0.4 — Python API reference correctness
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbport"
-version = "0.0.2"
+version = "0.0.3"
 description = "DuckDB-native runtime for building reproducible warehouse datasets"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/dbport/cli/main.py
+++ b/src/dbport/cli/main.py
@@ -31,7 +31,7 @@ def _version_callback(value: bool) -> None:
         try:
             v = version("dbport")
         except Exception:
-            v = "0.1.0"
+            v = "unknown"
         typer.echo(f"dbp {v}")
         raise typer.Exit()
 

--- a/tests/test_dbport/cli/test_main.py
+++ b/tests/test_dbport/cli/test_main.py
@@ -28,13 +28,13 @@ class TestAppHelp:
         assert "dbp" in result.output
 
     def test_version_fallback_on_error(self):
-        """When importlib.metadata.version raises, fallback to 0.1.0."""
+        """When importlib.metadata.version raises, fallback to 'unknown'."""
         from unittest.mock import patch
 
         with patch("importlib.metadata.version", side_effect=Exception("not installed")):
             result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert "unknown" in result.output
 
     def test_config_subcommand_in_help(self):
         result = runner.invoke(app, ["--help"])

--- a/zensical.toml
+++ b/zensical.toml
@@ -35,6 +35,7 @@ nav = [
     ]},
     { "Changelog" = "changelog.md" },
     { "Roadmap" = "roadmap.md" },
+    { "Release Versioning" = "release-versioning.md" },
 ]
 
 [project.theme]


### PR DESCRIPTION
## Summary

This PR establishes the project's release versioning policy and ensures all version-bearing surfaces derive from a single source of truth in `pyproject.toml`. It includes comprehensive documentation, updates the version to `0.0.3`, and fixes the CLI version fallback behavior.

## Key Changes

- **New versioning documentation** — Added `docs/release-versioning.md` documenting the `X.Y.Z` numbering scheme (major / normal / minor), the predevelopment milestone path from `0.0.1` to `0.1.0`, the single source of truth in `pyproject.toml`, and a per-version release checklist
- **Fixed CLI version fallback** — Changed `dbp --version` to report `"unknown"` instead of hard-coded `"0.1.0"` when `importlib.metadata` cannot resolve the package version, preventing misleading version reporting
- **Updated version to 0.0.3** — Bumped `pyproject.toml` version and added corresponding changelog entry
- **Updated project roadmap** — Marked the 0.0.3 milestone as complete and updated navigation to include the new Release Versioning page
- **Updated test expectations** — Modified `test_version_fallback_on_error` to expect `"unknown"` instead of `"0.1.0"`

## Implementation Details

The versioning policy establishes that:
- `pyproject.toml` is the single source of truth for package version
- All version surfaces (`dbp --version`, docs deployment, git tags, release automation) derive from this value
- No hard-coded version strings exist in source code
- The CLI gracefully reports `"unknown"` rather than guessing when package metadata is unavailable

This ensures consistency across the project and prevents accidental version mismatches between the installed package and what the CLI reports.

https://claude.ai/code/session_01LVBXimwB6BpPvmckbrDe6v