### PR TITLE
Lock DBPort public API surface and complete Python reference docs

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -21,17 +21,29 @@ DBPort(
     s3_secret_key: str | None = None,   # falls back to AWS_SECRET_ACCESS_KEY
     duckdb_path: str | None = None,     # default: <caller_dir>/data/<dataset_id>.duckdb
     lock_path: str | None = None,       # default: repo root (next to pyproject.toml)
+    model_root: str | None = None,      # default: caller's directory (auto-detected)
+    load_inputs_on_init: bool = True,   # reload lock-file inputs on startup
+    config_only: bool = False,          # lightweight mode (no DuckDB/catalog)
 )
 ```
 
-On initialization, `DBPort`:
+### Parameters
 
-- Resolves and validates credentials
-- Creates the `data/` directory if it does not exist
-- Opens (or creates) the file-backed DuckDB database
-- Connects to the Iceberg REST catalog
-- Reads (or creates) the `dbport.lock` file
-- Updates `last_fetched_at` in the warehouse table properties
+| Parameter | Default | Description |
+|---|---|---|
+| `agency` | *(required)* | Agency namespace (e.g. `"wifor"`, `"estat"`) |
+| `dataset_id` | *(required)* | Dataset identifier (e.g. `"emp__regional_trends"`) |
+| `catalog_uri` | `None` | Iceberg REST catalog URL. Falls back to `ICEBERG_REST_URI` |
+| `catalog_token` | `None` | Bearer token for catalog. Falls back to `ICEBERG_CATALOG_TOKEN` |
+| `warehouse` | `None` | Warehouse name. Falls back to `ICEBERG_WAREHOUSE` |
+| `s3_endpoint` | `None` | S3-compatible endpoint. Falls back to `S3_ENDPOINT` |
+| `s3_access_key` | `None` | S3 access key. Falls back to `AWS_ACCESS_KEY_ID` |
+| `s3_secret_key` | `None` | S3 secret key. Falls back to `AWS_SECRET_ACCESS_KEY` |
+| `duckdb_path` | `None` | Path to the DuckDB file. Default: `<model_root>/data/<dataset_id>.duckdb` |
+| `lock_path` | `None` | Path to `dbport.lock`. Default: repo root (next to `pyproject.toml`) |
+| `model_root` | `None` | Model directory for resolving SQL file paths and the default DuckDB location. Default: auto-detected from the calling script's directory |
+| `load_inputs_on_init` | `True` | When `True`, inputs previously declared in `dbport.lock` are reloaded into DuckDB on startup. Set to `False` to skip automatic input loading |
+| `config_only` | `False` | Lightweight mode — see [Full mode vs. config_only](#full-mode-vs-config_only) |
 
 ### Context manager (recommended)
 
@@ -43,12 +55,58 @@ with DBPort(agency="wifor", dataset_id="emp__regional_trends") as port:
 
 ---
 
+## Initialization behavior
+
+Creating a `DBPort` instance runs through four phases. In **full mode** (default):
+
+1. **Path resolution** — discovers the model root directory (from `model_root` kwarg or auto-detected from the calling script), walks up to `pyproject.toml` to find the repo root, and derives the lock path and DuckDB path.
+
+2. **Credential resolution** — merges explicit constructor kwargs with environment variables via `WarehouseCreds`. Explicit kwargs always take precedence.
+
+3. **Adapter wiring** — creates the lock adapter (reads/initializes `dbport.lock`), opens DuckDB, connects to the Iceberg REST catalog, and sets up the in-memory metadata builder.
+
+4. **State sync** — runs four operations, all of which are resilient to errors (logged but never fail initialization):
+
+    | Step | What it does | On error |
+    |---|---|---|
+    | Auto-detect schema | If no user-declared schema exists in the lock, checks the warehouse for an existing table and imports its schema | Logged at debug level; skipped |
+    | Sync output table | Creates the output table in DuckDB from the lock file schema (skipped if the table already exists) | Logged at warning level; skipped |
+    | Update `last_fetched_at` | Writes a timestamp to the warehouse table properties (no new snapshot) | Logged at debug level; skipped |
+    | Reload inputs | Reloads all inputs declared in `dbport.lock` into DuckDB (only when `load_inputs_on_init=True`) | Per-input errors logged; other inputs still loaded |
+
+In **config_only mode**, only the lock adapter and column registry are created. All sync phases are skipped entirely.
+
+---
+
+## Full mode vs. `config_only`
+
+| Aspect | Full mode (default) | `config_only=True` |
+|---|---|---|
+| Credentials | Required (kwargs or env vars) | Not needed |
+| DuckDB | Opened; `data/` directory created | Not opened; no directory created |
+| Catalog connection | Established | Not established |
+| Lock file | Read/initialized | Read/initialized |
+| State sync | All four phases run | All skipped |
+| `columns.meta()` / `columns.attach()` | Works | Works |
+| `schema()`, `load()`, `execute()`, `run()`, `configure_input()`, `publish()` | Works | Raises `RuntimeError` |
+| `close()` | Releases DuckDB | No-op |
+
+Use `config_only=True` when you need to manipulate column metadata or lock file state without warehouse access:
+
+```python
+with DBPort(agency="wifor", dataset_id="emp__regional_trends", config_only=True) as port:
+    port.columns.nuts2024.meta(codelist_id="NUTS2024", codelist_kind="hierarchical")
+    port.columns.nuts2024.attach(table="wifor.cl_nuts2024")
+```
+
+---
+
 ## `port.schema(ddl)`
 
 Declares the output table schema. Accepts an inline DDL string or a path to a `.sql` file.
 
 ```python
-# Path to a .sql file (resolved relative to the caller's directory)
+# Path to a .sql file (resolved relative to model_root)
 port.schema("sql/create_output.sql")
 
 # Or inline DDL
@@ -70,7 +128,7 @@ Call `port.schema()` once, early in the script. Re-running the same DDL is idemp
 
 ---
 
-## `port.load(table_address, *, filters=None)`
+## `port.load(table_address, *, filters=None, version=None)`
 
 Loads an Iceberg table from the warehouse into DuckDB under its exact original address.
 
@@ -79,9 +137,40 @@ port.load("estat.nama_10r_3empers", filters={"wstatus": "EMP", "nace_r2": "TOTAL
 port.load("wifor.cl_nuts2024")
 ```
 
+**Returns**: `IngestRecord` — a frozen record of the completed ingest, including the snapshot ID, timestamp, row count, and any filters applied.
+
 **Snapshot-based caching**: if the table's snapshot has not changed and the DuckDB relation already exists, the load is skipped automatically.
 
 **No row cap**: `load()` always fetches the full table. Use `filters` to scope data.
+
+**Version pinning**: for tables published by DBPort, load is automatically pinned to a specific Iceberg snapshot. Pass an explicit `version` string to load a historical release:
+
+```python
+port.load("wifor.emp__regional_trends", version="2025-01-01")
+```
+
+For tables without DBPort metadata (e.g. Eurostat inputs), `version` is ignored and the current Iceberg snapshot is used.
+
+---
+
+## `port.configure_input(table_address, *, filters=None, version=None)`
+
+Validates and persists an input declaration to `dbport.lock` **without loading data**.
+
+```python
+port.configure_input("estat.nama_10r_3empers", filters={"wstatus": "EMP"})
+```
+
+**Returns**: `IngestRecord` — the persisted declaration.
+
+This is the configuration-only counterpart of `load()`:
+
+| Method | Validates | Persists to lock | Loads data into DuckDB |
+|---|---|---|---|
+| `load()` | Yes | Yes | Yes |
+| `configure_input()` | Yes | Yes | No |
+
+Use `configure_input()` when you want to declare inputs for the lock file (e.g. during project setup) without requiring warehouse connectivity for the actual data load.
 
 ---
 
@@ -127,12 +216,59 @@ port.execute("sql/staging.sql")
 port.execute("CREATE TABLE staging.ranked AS SELECT ...")
 ```
 
-For dynamic SQL, render the template before passing:
+File paths are resolved relative to `model_root`. For dynamic SQL, render the template before passing:
 
 ```python
 sql = template.format(level=2, parent_table="staging.bench_lvl1")
 port.execute(sql)
 ```
+
+---
+
+## `port.run(*, version=None, mode=None)`
+
+Executes the configured run hook, optionally publishing afterward.
+
+```python
+# Run the hook without publishing
+port.run()
+
+# Run the hook and publish
+port.run(version="2026-03-09", mode="dry")
+```
+
+### Hook resolution
+
+The run hook is resolved in this order:
+
+1. Explicit hook path set in `dbport.lock` (via CLI `dbp config run-hook`)
+2. `main.py` in the model root (if it exists)
+3. `sql/main.sql` in the model root (if it exists)
+4. Falls back to `main.py` (may not exist — will error on execution)
+
+### Hook dispatch by file extension
+
+| Extension | Behavior |
+|---|---|
+| `.sql` | Executed via `port.execute()` |
+| `.py` | Loaded as a Python module with `port` available in scope. If the module defines a top-level `run(port)` function, it is called after the module is loaded |
+| Other | Raises `ValueError` |
+
+### Optional publish
+
+When `version` is provided, `port.publish(version=version, mode=mode)` is called automatically after the hook completes. When `version` is `None`, the hook runs without publishing.
+
+---
+
+## `port.run_hook`
+
+Read-only property that returns the resolved hook path as a string, or `None` if no hook can be found.
+
+```python
+print(port.run_hook)  # e.g. "main.py" or "sql/main.sql"
+```
+
+This returns the path that `port.run()` would execute, without actually running it. Useful for inspection and debugging.
 
 ---
 
@@ -173,7 +309,7 @@ port.publish(
 
 ## `port.close()`
 
-Closes the DuckDB connection. Called automatically when using the context manager.
+Closes the DuckDB connection. Called automatically when using the context manager. In `config_only` mode, this is a no-op.
 
 ---
 
@@ -182,7 +318,7 @@ Closes the DuckDB connection. Called automatically when using the context manage
 | Exception | When raised |
 |---|---|
 | `ValidationError` | Missing required credentials |
-| `ValueError` | Invalid DDL string passed to `schema()` |
-| `RuntimeError` | `publish()` called before `schema()`; DuckDB extension unavailable |
+| `ValueError` | Invalid DDL string passed to `schema()`; unsupported hook file extension |
+| `RuntimeError` | `publish()` called before `schema()`; data method called in `config_only` mode; DuckDB extension unavailable |
 | `SchemaDriftError` | Local schema incompatible with warehouse (raised by both `schema()` and `publish()`) |
 | `FileNotFoundError` | `.sql` file path does not exist |

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -6,6 +6,23 @@
 from dbport import DBPort
 ```
 
+## Quick reference
+
+| Method | Purpose |
+|---|---|
+| [`DBPort(agency, dataset_id, ...)`](#constructor) | Create a client instance with credentials and paths |
+| [`port.schema(ddl_or_path)`](#schema) | Declare the output table schema |
+| [`port.load(table, filters, version)`](#load) | Load an Iceberg table into DuckDB |
+| [`port.configure_input(table, filters, version)`](#configure_input) | Persist an input declaration without loading data |
+| [`port.columns.<name>.meta(...)`](#meta) | Override codelist metadata for a column |
+| [`port.columns.<name>.attach(table)`](#attach) | Use a DuckDB table as codelist source |
+| [`port.execute(sql_or_path)`](#execute) | Run SQL in DuckDB |
+| [`port.run(version, mode)`](#run) | Execute the configured run hook |
+| [`port.publish(version, params, mode)`](#publish) | Write output to the Iceberg warehouse |
+| [`port.close()`](#close) | Release resources |
+
+---
+
 ## Constructor
 
 ```python
@@ -13,17 +30,17 @@ DBPort(
     agency: str,
     dataset_id: str,
     *,
-    catalog_uri: str | None = None,     # falls back to ICEBERG_REST_URI
-    catalog_token: str | None = None,   # falls back to ICEBERG_CATALOG_TOKEN
-    warehouse: str | None = None,       # falls back to ICEBERG_WAREHOUSE
-    s3_endpoint: str | None = None,     # falls back to S3_ENDPOINT
-    s3_access_key: str | None = None,   # falls back to AWS_ACCESS_KEY_ID
-    s3_secret_key: str | None = None,   # falls back to AWS_SECRET_ACCESS_KEY
-    duckdb_path: str | None = None,     # default: <caller_dir>/data/<dataset_id>.duckdb
-    lock_path: str | None = None,       # default: repo root (next to pyproject.toml)
-    model_root: str | None = None,      # default: caller's directory (auto-detected)
-    load_inputs_on_init: bool = True,   # reload lock-file inputs on startup
-    config_only: bool = False,          # lightweight mode (no DuckDB/catalog)
+    catalog_uri: str | None = None,
+    catalog_token: str | None = None,
+    warehouse: str | None = None,
+    s3_endpoint: str | None = None,
+    s3_access_key: str | None = None,
+    s3_secret_key: str | None = None,
+    duckdb_path: str | None = None,
+    lock_path: str | None = None,
+    model_root: str | None = None,
+    load_inputs_on_init: bool = True,
+    config_only: bool = False,
 )
 ```
 
@@ -43,7 +60,7 @@ DBPort(
 | `lock_path` | `None` | Path to `dbport.lock`. Default: repo root (next to `pyproject.toml`) |
 | `model_root` | `None` | Model directory for resolving SQL file paths and the default DuckDB location. Default: auto-detected from the calling script's directory |
 | `load_inputs_on_init` | `True` | When `True`, inputs previously declared in `dbport.lock` are reloaded into DuckDB on startup. Set to `False` to skip automatic input loading |
-| `config_only` | `False` | Lightweight mode — see [Full mode vs. config_only](#full-mode-vs-config_only) |
+| `config_only` | `False` | Lightweight mode — see [Full mode vs. config_only](#full-mode-vs-config_only) below |
 
 ### Context manager (recommended)
 
@@ -53,11 +70,9 @@ with DBPort(agency="wifor", dataset_id="emp__regional_trends") as port:
 # port.close() is called automatically
 ```
 
----
+### Initialization behavior
 
-## Initialization behavior
-
-Creating a `DBPort` instance runs through four phases. In **full mode** (default):
+Creating a `DBPort` instance runs through four phases:
 
 1. **Path resolution** — discovers the model root directory (from `model_root` kwarg or auto-detected from the calling script), walks up to `pyproject.toml` to find the repo root, and derives the lock path and DuckDB path.
 
@@ -65,7 +80,7 @@ Creating a `DBPort` instance runs through four phases. In **full mode** (default
 
 3. **Adapter wiring** — creates the lock adapter (reads/initializes `dbport.lock`), opens DuckDB, connects to the Iceberg REST catalog, and sets up the in-memory metadata builder.
 
-4. **State sync** — runs four operations, all of which are resilient to errors (logged but never fail initialization):
+4. **State sync** — runs four operations, all resilient to errors (logged but never fail initialization):
 
     | Step | What it does | On error |
     |---|---|---|
@@ -74,11 +89,7 @@ Creating a `DBPort` instance runs through four phases. In **full mode** (default
     | Update `last_fetched_at` | Writes a timestamp to the warehouse table properties (no new snapshot) | Logged at debug level; skipped |
     | Reload inputs | Reloads all inputs declared in `dbport.lock` into DuckDB (only when `load_inputs_on_init=True`) | Per-input errors logged; other inputs still loaded |
 
-In **config_only mode**, only the lock adapter and column registry are created. All sync phases are skipped entirely.
-
----
-
-## Full mode vs. `config_only`
+### Full mode vs. `config_only`
 
 | Aspect | Full mode (default) | `config_only=True` |
 |---|---|---|
@@ -101,15 +112,36 @@ with DBPort(agency="wifor", dataset_id="emp__regional_trends", config_only=True)
 
 ---
 
-## `port.schema(ddl)`
+## Methods
 
-Declares the output table schema. Accepts an inline DDL string or a path to a `.sql` file.
+Methods are listed in typical workflow order: declare schema, load inputs, configure columns, transform, run, publish.
+
+### `schema()` { #schema }
 
 ```python
-# Path to a .sql file (resolved relative to model_root)
+port.schema(ddl_or_path: str) -> None
+```
+
+Declares the output table schema from a DDL string or `.sql` file path.
+
+**Parameters:**
+
+- **`ddl_or_path`** (`str`) — A `CREATE TABLE` DDL string, or a path to a `.sql` file (resolved relative to `model_root`).
+
+**Returns:** `None`
+
+**Raises:**
+
+- `ValueError` — Invalid DDL string.
+- `SchemaDriftError` — Local DDL is incompatible with the existing warehouse table.
+
+**Examples:**
+
+```python
+# From a .sql file
 port.schema("sql/create_output.sql")
 
-# Or inline DDL
+# Inline DDL
 port.schema("""
     CREATE OR REPLACE TABLE wifor.emp__regional_trends (
         freq     VARCHAR,
@@ -124,44 +156,75 @@ The table is created in DuckDB and the schema (DDL + column list) is persisted t
 
 Call `port.schema()` once, early in the script. Re-running the same DDL is idempotent.
 
-**Warehouse validation**: if the output table already exists in the warehouse, `port.schema()` compares the local DDL against the warehouse schema. Raises `SchemaDriftError` if incompatible.
-
 ---
 
-## `port.load(table_address, *, filters=None, version=None)`
+### `load()` { #load }
+
+```python
+port.load(
+    table_address: str,
+    *,
+    filters: dict[str, str] | None = None,
+    version: str | None = None,
+) -> IngestRecord
+```
 
 Loads an Iceberg table from the warehouse into DuckDB under its exact original address.
+
+**Parameters:**
+
+- **`table_address`** (`str`) — Fully-qualified table address (e.g. `"estat.nama_10r_3empers"`).
+- **`filters`** (`dict[str, str] | None`) — Optional equality filters pushed to the Iceberg scan (e.g. `{"wstatus": "EMP"}`). Default: `None` (loads all rows).
+- **`version`** (`str | None`) — Pin to a specific dataset version (e.g. `"2025-01-01"`). Default: `None` (latest version). Ignored for tables without DBPort metadata.
+
+**Returns:** `IngestRecord` — a frozen record of the completed ingest, including the snapshot ID, timestamp, row count, and any filters applied.
+
+**Raises:**
+
+- `RuntimeError` — Called in `config_only` mode.
+
+**Examples:**
 
 ```python
 port.load("estat.nama_10r_3empers", filters={"wstatus": "EMP", "nace_r2": "TOTAL"})
 port.load("wifor.cl_nuts2024")
-```
 
-**Returns**: `IngestRecord` — a frozen record of the completed ingest, including the snapshot ID, timestamp, row count, and any filters applied.
+# Pin to a specific version
+port.load("wifor.emp__regional_trends", version="2025-01-01")
+```
 
 **Snapshot-based caching**: if the table's snapshot has not changed and the DuckDB relation already exists, the load is skipped automatically.
 
 **No row cap**: `load()` always fetches the full table. Use `filters` to scope data.
 
-**Version pinning**: for tables published by DBPort, load is automatically pinned to a specific Iceberg snapshot. Pass an explicit `version` string to load a historical release:
-
-```python
-port.load("wifor.emp__regional_trends", version="2025-01-01")
-```
-
-For tables without DBPort metadata (e.g. Eurostat inputs), `version` is ignored and the current Iceberg snapshot is used.
-
 ---
 
-## `port.configure_input(table_address, *, filters=None, version=None)`
+### `configure_input()` { #configure_input }
+
+```python
+port.configure_input(
+    table_address: str,
+    *,
+    filters: dict[str, str] | None = None,
+    version: str | None = None,
+) -> IngestRecord
+```
 
 Validates and persists an input declaration to `dbport.lock` **without loading data**.
+
+**Parameters:** Same as [`load()`](#load).
+
+**Returns:** `IngestRecord` — the persisted declaration.
+
+**Raises:**
+
+- `RuntimeError` — Called in `config_only` mode.
+
+**Example:**
 
 ```python
 port.configure_input("estat.nama_10r_3empers", filters={"wstatus": "EMP"})
 ```
-
-**Returns**: `IngestRecord` — the persisted declaration.
 
 This is the configuration-only counterpart of `load()`:
 
@@ -174,11 +237,31 @@ Use `configure_input()` when you want to declare inputs for the lock file (e.g. 
 
 ---
 
-## `port.columns.<name>`
+### `columns` { #columns }
 
 Attribute-style access to per-column metadata. Changes are persisted to `dbport.lock` immediately.
 
-### `.meta(...)` — override codelist metadata
+#### `.meta(...)` — override codelist metadata { #meta }
+
+```python
+port.columns.<name>.meta(
+    codelist_id: str | None = None,
+    codelist_kind: str | None = None,
+    codelist_type: str | None = None,
+    codelist_labels: dict[str, str] | None = None,
+) -> ColumnConfig
+```
+
+**Parameters:**
+
+- **`codelist_id`** (`str | None`) — Identifier for the codelist. Default: column name.
+- **`codelist_kind`** (`str | None`) — `"flat"` or `"hierarchical"`. Default: inferred from SQL type.
+- **`codelist_type`** (`str | None`) — Value type hint. Default: inferred from SQL type.
+- **`codelist_labels`** (`dict[str, str] | None`) — Human-readable labels per language. Default: `None`.
+
+**Returns:** `ColumnConfig` (self, for chaining).
+
+**Example:**
 
 ```python
 port.columns.nuts2024.meta(
@@ -188,46 +271,81 @@ port.columns.nuts2024.meta(
 )
 ```
 
-| Parameter | Default | Description |
-|---|---|---|
-| `codelist_id` | column name | Identifier for the codelist |
-| `codelist_kind` | inferred from SQL type | `"flat"` or `"hierarchical"` |
-| `codelist_type` | inferred from SQL type | Value type hint |
-| `codelist_labels` | `null` | Human-readable labels per language |
+#### `.attach(table=...)` — use a DuckDB table as codelist source { #attach }
 
-Returns `self` for chaining.
+```python
+port.columns.<name>.attach(table: str) -> ColumnConfig
+```
 
-### `.attach(table=...)` — use a DuckDB table as codelist source
+**Parameters:**
+
+- **`table`** (`str`) — Address of a DuckDB table to use as the codelist source. Should already be loaded via `port.load()`.
+
+**Returns:** `ColumnConfig` (self, for chaining).
+
+**Example:**
 
 ```python
 port.columns.nuts2024.attach(table="wifor.cl_nuts2024")
 ```
 
-The table should already be loaded via `port.load()`. On `publish()`, the full table is exported as the codelist.
+On `publish()`, the full table is exported as the codelist for this column.
 
 ---
 
-## `port.execute(sql)`
+### `execute()` { #execute }
+
+```python
+port.execute(sql_or_path: str) -> None
+```
 
 Runs a SQL statement or a `.sql` file in DuckDB.
+
+**Parameters:**
+
+- **`sql_or_path`** (`str`) — Inline SQL string, or a path to a `.sql` file (resolved relative to `model_root`).
+
+**Returns:** `None`
+
+**Raises:**
+
+- `FileNotFoundError` — `.sql` file path does not exist.
+- `RuntimeError` — Called in `config_only` mode.
+
+**Examples:**
 
 ```python
 port.execute("sql/staging.sql")
 port.execute("CREATE TABLE staging.ranked AS SELECT ...")
-```
 
-File paths are resolved relative to `model_root`. For dynamic SQL, render the template before passing:
-
-```python
+# Dynamic SQL
 sql = template.format(level=2, parent_table="staging.bench_lvl1")
 port.execute(sql)
 ```
 
 ---
 
-## `port.run(*, version=None, mode=None)`
+### `run()` { #run }
+
+```python
+port.run(*, version: str | None = None, mode: str | None = None) -> None
+```
 
 Executes the configured run hook, optionally publishing afterward.
+
+**Parameters:**
+
+- **`version`** (`str | None`) — When provided, `publish(version=version, mode=mode)` is called automatically after the hook completes. Default: `None` (no publish).
+- **`mode`** (`str | None`) — Publish mode, forwarded to `publish()`. Only used when `version` is set. See [`publish()`](#publish) for valid values.
+
+**Returns:** `None`
+
+**Raises:**
+
+- `ValueError` — Hook file has an unsupported extension (not `.py` or `.sql`).
+- `RuntimeError` — Called in `config_only` mode.
+
+**Examples:**
 
 ```python
 # Run the hook without publishing
@@ -237,7 +355,7 @@ port.run()
 port.run(version="2026-03-09", mode="dry")
 ```
 
-### Hook resolution
+#### Hook resolution
 
 The run hook is resolved in this order:
 
@@ -246,7 +364,7 @@ The run hook is resolved in this order:
 3. `sql/main.sql` in the model root (if it exists)
 4. Falls back to `main.py` (may not exist — will error on execution)
 
-### Hook dispatch by file extension
+#### Hook dispatch by file extension
 
 | Extension | Behavior |
 |---|---|
@@ -254,27 +372,55 @@ The run hook is resolved in this order:
 | `.py` | Loaded as a Python module with `port` available in scope. If the module defines a top-level `run(port)` function, it is called after the module is loaded |
 | Other | Raises `ValueError` |
 
-### Optional publish
-
-When `version` is provided, `port.publish(version=version, mode=mode)` is called automatically after the hook completes. When `version` is `None`, the hook runs without publishing.
-
----
-
-## `port.run_hook`
-
-Read-only property that returns the resolved hook path as a string, or `None` if no hook can be found.
+#### `port.run_hook` property
 
 ```python
-print(port.run_hook)  # e.g. "main.py" or "sql/main.sql"
+port.run_hook -> str | None
 ```
 
-This returns the path that `port.run()` would execute, without actually running it. Useful for inspection and debugging.
+Read-only property that returns the resolved hook path as a string, or `None` if no hook can be found. Returns the path that `run()` would execute, without actually running it.
 
 ---
 
-## `port.publish(*, version, params=None, mode=None)`
+### `publish()` { #publish }
+
+```python
+port.publish(
+    *,
+    version: str,
+    params: dict[str, str] | None = None,
+    mode: str | None = None,
+) -> None
+```
 
 Writes the output table from DuckDB to the Iceberg warehouse.
+
+**Parameters:**
+
+- **`version`** (`str`) — Version label for this publish (e.g. `"2026-03-09"`). Required.
+- **`params`** (`dict[str, str] | None`) — Key-value parameters describing this version (e.g. `{"wstatus": "EMP"}`). Default: `None`.
+- **`mode`** (`str | None`) — Publish mode. Default: `None`.
+
+| `mode` value | Behavior |
+|---|---|
+| `None` (default) | Idempotent — skip if version already completed; resume from checkpoint if interrupted |
+| `"dry"` | Schema validation only — no data written |
+| `"refresh"` | Overwrite existing version unconditionally |
+
+**Returns:** `None`
+
+**Raises:**
+
+- `RuntimeError` — `port.schema()` has not been called; or called in `config_only` mode.
+- `SchemaDriftError` — Local schema incompatible with warehouse.
+
+**Pre-publish checks** (in order):
+
+1. **Schema defined** — raises `RuntimeError` if `port.schema()` has not been called
+2. **Version idempotency** — if version already completed, returns immediately (skipped in `refresh` mode)
+3. **Schema drift** — compares local vs warehouse schema; raises `SchemaDriftError` with a diff if incompatible
+
+**Example:**
 
 ```python
 port.publish(
@@ -283,21 +429,7 @@ port.publish(
 )
 ```
 
-### `mode` parameter
-
-| Value | Behavior |
-|---|---|
-| `None` (default) | Idempotent — skip if version already completed; resume from checkpoint if interrupted |
-| `"dry"` | Schema validation only — no data written |
-| `"refresh"` | Overwrite existing version unconditionally |
-
-### Pre-publish checks (in order)
-
-1. **Schema defined** — raises `RuntimeError` if `port.schema()` has not been called
-2. **Version idempotency** — if version already completed, returns immediately (skipped in `refresh` mode)
-3. **Schema drift** — compares local vs warehouse schema; raises `SchemaDriftError` with a diff if incompatible
-
-### On success
+**On success:**
 
 - Data written to `<agency>.<dataset_id>` in Iceberg
 - Codelists auto-generated per column
@@ -307,9 +439,47 @@ port.publish(
 
 ---
 
-## `port.close()`
+### `close()` { #close }
+
+```python
+port.close() -> None
+```
 
 Closes the DuckDB connection. Called automatically when using the context manager. In `config_only` mode, this is a no-op.
+
+**Parameters:** None
+
+**Returns:** `None`
+
+---
+
+## Complete example
+
+```python
+from dbport import DBPort
+
+with DBPort(agency="wifor", dataset_id="emp__regional_trends") as port:
+
+    # 1. Declare output schema
+    port.schema("sql/create_output.sql")
+
+    # 2. Column metadata
+    port.columns.nuts2024.meta(codelist_id="NUTS2024", codelist_kind="hierarchical")
+    port.columns.nuts2024.attach(table="wifor.cl_nuts2024")
+
+    # 3. Load inputs from warehouse
+    port.load("estat.nama_10r_3empers", filters={"wstatus": "EMP"})
+    port.load("wifor.cl_nuts2024")
+
+    # 4. Run SQL transforms
+    port.execute("sql/staging.sql")
+    port.execute("sql/final_output.sql")
+
+    # 5. Publish to warehouse
+    port.publish(version="2026-03-09", params={"wstatus": "EMP"})
+```
+
+See also: [Python workflow example](../examples/python-workflow.md), [CLI workflow example](../examples/cli-workflow.md).
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -238,9 +238,43 @@ Status: `done`
 
 | Item | Priority | Summary |
 |---|---|---|
-| DBP-DOC-001 | `P0` | Python API reference expanded to cover all 13 constructor parameters, `configure_input()`, `run()`, `run_hook`, initialization behavior, full mode vs. `config_only`, and hook resolution |
-| DBP-API-001 | `P0` | 33 contract tests lock the public surface: module exports, constructor signature, method/property inventory, method signatures, `config_only` guards, return types, and init behavior |
-| DBP-API-002 | `P0` | Init semantics documented and stabilized; `_sync_output_state` errors promoted to warning; `FetchService` exception handler now logs instead of silent pass; detailed docstrings on all init phases |
+| DBP-DOC-001 | `P0` | Python API reference rewritten for completeness and readability |
+| DBP-API-001 | `P0` | 33 contract tests lock the public `DBPort` surface |
+| DBP-API-002 | `P0` | Init semantics documented and stabilized; silent fallbacks tightened |
+
+#### DBP-DOC-001 — Python API reference
+
+- Documented all 13 constructor parameters including `model_root`, `load_inputs_on_init`, and `config_only`
+- Documented `configure_input()`, `run()`, and `run_hook` property
+- Added "Initialization behavior" section with sync phase table and error guarantees
+- Added "Full mode vs. config_only" comparison table
+- Added `load()` vs. `configure_input()` comparison table
+- Documented hook resolution order and dispatch-by-extension rules
+- Restructured page for readability: Quick Reference table at top, H2 for Constructor/Methods/Example/Errors, H3 for individual methods (TOC from 13 flat entries to 5 top-level)
+- Standardized every method section to consistent template: signature → parameters → returns → raises → example
+- Merged `run_hook` property into `run()` section (reduces visual noise)
+- Added "Complete example" section at the bottom showing full workflow
+- Added anchor IDs on all method headings for cross-linking from Quick Reference
+
+#### DBP-API-001 — Contract tests
+
+- Created `tests/test_dbport/adapters/primary/test_contract.py` (33 tests)
+- `TestModuleExports` — `__all__ == ["DBPort"]`, importability
+- `TestConstructorSignature` — 2 positional + 11 keyword-only params with correct defaults, total count
+- `TestPublicSurface` — 7 methods, 1 property, context manager protocol, `columns` attribute
+- `TestMethodSignatures` — parameter names and defaults for all 6 public methods
+- `TestConfigOnlyContract` — 6 guarded methods raise `RuntimeError`; `columns.meta()`, `columns.attach()`, `close()`, context manager, and `run_hook` work
+- `TestReturnTypes` — `load()` and `configure_input()` return `IngestRecord`
+- `TestInitBehavior` — full mode calls all 4 sync phases; `load_inputs_on_init=False` skips input loading; `config_only` skips all sync; sync errors do not fail init
+
+#### DBP-API-002 — Init semantics
+
+- Added detailed docstring to `__init__` documenting all 4 initialization phases and `config_only` behavior
+- Added detailed docstrings to `_auto_detect_schema`, `_sync_output_state`, `_load_inputs`, `_update_last_fetched`
+- Promoted `_sync_output_state` error logging from `debug` to `warning` (user-relevant failure)
+- Added `logger` import to `FetchService` and replaced bare `pass` with `logger.debug(...)` in exception handler
+- Version bumped to `0.0.4` in `pyproject.toml`
+- Updated `docs/changelog.md`, `docs/roadmap.md`
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -181,10 +181,12 @@ Status: `done`
 
 Theme: Python API reference correctness.
 
+Status: `done`
+
 ### DBP-DOC-001 - Complete Python API reference
 
 - Priority: `P0`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/api/python.md`
 - Required changes:
@@ -199,7 +201,7 @@ Theme: Python API reference correctness.
 ### DBP-API-001 - Freeze the supported Python client contract before public release
 
 - Priority: `P0`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `src/dbport/__init__.py`
   - `src/dbport/adapters/primary/client.py`
@@ -216,7 +218,7 @@ Theme: Python API reference correctness.
 ### DBP-API-002 - Make `DBPort(...)` startup semantics explicit and stable
 
 - Priority: `P0`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `src/dbport/adapters/primary/client.py`
   - `src/dbport/application/services/sync.py`
@@ -231,6 +233,14 @@ Theme: Python API reference correctness.
   - Ensure constructor behavior is predictable enough to freeze as part of the public client contract
 - Acceptance criteria:
   - Creating a `DBPort` instance has deliberate, documented, and testable semantics suitable for a stable public release
+
+### Items delivered
+
+| Item | Priority | Summary |
+|---|---|---|
+| DBP-DOC-001 | `P0` | Python API reference expanded to cover all 13 constructor parameters, `configure_input()`, `run()`, `run_hook`, initialization behavior, full mode vs. `config_only`, and hook resolution |
+| DBP-API-001 | `P0` | 33 contract tests lock the public surface: module exports, constructor signature, method/property inventory, method signatures, `config_only` guards, return types, and init behavior |
+| DBP-API-002 | `P0` | Init semantics documented and stabilized; `_sync_output_state` errors promoted to warning; `FetchService` exception handler now logs instead of silent pass; detailed docstrings on all init phases |
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,27 @@ Each entry includes: version number, release date, and a summary of changes grou
 
 ---
 
+## 0.0.4 — 2026-03-17
+
+Python API reference correctness.
+
+### Added
+
+- **Complete Python API reference** — documented `model_root`, `load_inputs_on_init`, `config_only` constructor parameters; documented `port.configure_input()`, `port.run()`, and `port.run_hook`; added sections for initialization behavior, full mode vs. `config_only`, hook resolution, and the relationship between `load()` and `configure_input()`
+- **Python client contract tests** — 33 tests in `test_contract.py` that lock the public `DBPort` surface: module exports, constructor signature, public method/property inventory, method signatures, `config_only` guards, return types, and initialization behavior
+- **Initialization behavior documentation** — documented the four init phases (path resolution, credential resolution, adapter wiring, state sync) and the error resilience guarantees for each sync step
+
+### Changed
+
+- **Sync output warning level** — `_sync_output_state()` errors now log at warning level instead of debug, since a failed output table creation is user-relevant
+- **FetchService error logging** — `FetchService.execute()` now logs failed `last_fetched_at` updates at debug level instead of silently swallowing exceptions
+
+### Improved
+
+- **Init method docstrings** — added detailed docstrings to `__init__`, `_auto_detect_schema`, `_sync_output_state`, `_load_inputs`, and `_update_last_fetched` documenting their behavior, error handling, and guarantees
+
+---
+
 ## 0.0.3 — 2026-03-17
 
 Version policy and release planning language.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ For completed work, see the [Changelog](changelog.md).
 | 0.0.1 | Foundation: runtime, architecture, CLI, docs site, CI | Done |
 | 0.0.2 | Release history and roadmap foundations | Done |
 | 0.0.3 | Version policy and release planning language | Done |
-| 0.0.4 | Python API reference correctness | Planned |
+| 0.0.4 | Python API reference correctness | Done |
 | 0.0.5 | CLI reference and executable workflows | Planned |
 | 0.0.6 | Public package surface and repository trustworthiness | Planned |
 | 0.0.7 | Execution model and conceptual docs depth | Planned |
@@ -31,9 +31,9 @@ For completed work, see the [Changelog](changelog.md).
 
 ## 0.0.4 — Python API reference correctness
 
-- Complete the Python API reference to match the full `DBPort` surface
-- Freeze the supported Python client contract for `0.1.0`
-- Make `DBPort(...)` startup semantics explicit and stable
+- ~~Complete the Python API reference to match the full `DBPort` surface~~
+- ~~Freeze the supported Python client contract for `0.1.0`~~
+- ~~Make `DBPort(...)` startup semantics explicit and stable~~
 
 ## 0.0.5 — CLI reference and executable workflows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbport"
-version = "0.0.3"
+version = "0.0.4"
 description = "DuckDB-native runtime for building reproducible warehouse datasets"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/dbport/adapters/primary/client.py
+++ b/src/dbport/adapters/primary/client.py
@@ -89,6 +89,28 @@ class DBPort:
         load_inputs_on_init: bool = True,
         config_only: bool = False,
     ) -> None:
+        """Initialize a DBPort instance.
+
+        In **full mode** (default), initialization performs these phases:
+
+        1. **Path resolution** — discovers ``model_root`` (from the calling
+           script's directory or the explicit *model_root* kwarg), repo root
+           (walks up to ``pyproject.toml``), lock path, and DuckDB path.
+        2. **Credential resolution** — merges explicit kwargs with environment
+           variables via ``WarehouseCreds``.
+        3. **Adapter wiring** — creates lock, compute (DuckDB), catalog
+           (Iceberg REST), and metadata adapters.
+        4. **State sync** — auto-detects schema from warehouse, syncs the
+           output table in DuckDB, updates ``last_fetched_at``, and (when
+           *load_inputs_on_init* is True) reloads previously configured
+           inputs.  All sync errors are logged but never fail initialization.
+
+        In **config_only** mode, only the lock adapter and column registry
+        are created.  No credentials, DuckDB, or catalog connection are
+        required.  Data methods (``schema``, ``load``, ``execute``, ``run``,
+        ``configure_input``, ``publish``) raise ``RuntimeError`` if called.
+        Column metadata methods (``.meta()``, ``.attach()``) work normally.
+        """
         setup_logging()
 
         # ------------------------------------------------------------------
@@ -393,7 +415,14 @@ class DBPort:
         return MetadataAdapter()
 
     def _auto_detect_schema(self) -> None:
-        """Auto-detect output schema from warehouse table if it exists."""
+        """Auto-detect output schema from warehouse table if it exists.
+
+        Skipped when a user-declared schema (``source='local'``) is already
+        present in the lock file.  On success, the detected schema is
+        persisted to the lock with ``source='warehouse'`` and the column
+        registry is refreshed.  Errors are logged at debug level and never
+        fail initialization.
+        """
         from ...application.services.auto_schema import AutoSchemaService
         from ...infrastructure.progress import progress_callback
 
@@ -421,17 +450,27 @@ class DBPort:
             logger.debug("Auto-schema detection skipped: %s", exc)
 
     def _sync_output_state(self) -> None:
-        """Sync DuckDB output table with lock file state."""
+        """Create the output table in DuckDB from the lock file schema.
+
+        If the output table already exists in DuckDB (e.g. from a prior
+        run), DDL execution is skipped to preserve existing data.  Errors
+        are logged at warning level and never fail initialization.
+        """
         from ...application.services.sync import SyncService
 
         try:
             svc = SyncService(self._catalog, self._compute, self._lock)
             svc.sync_output_table(self._dataset.table_address)
         except Exception as exc:
-            logger.debug("Local sync skipped: %s", exc)
+            logger.warning("Local sync skipped: %s", exc)
 
     def _load_inputs(self) -> None:
-        """Load configured inputs into DuckDB."""
+        """Reload all inputs declared in the lock file into DuckDB.
+
+        Each input is loaded independently; a failure on one input is
+        logged at debug level and does not prevent other inputs from
+        loading.  Only called when ``load_inputs_on_init=True``.
+        """
         from ...application.services.sync import SyncService
 
         try:
@@ -441,6 +480,12 @@ class DBPort:
             logger.debug("Input sync skipped: %s", exc)
 
     def _update_last_fetched(self) -> None:
+        """Update ``dbport.last_fetched_at`` in the warehouse table properties.
+
+        Fire-and-forget: errors are logged at debug level inside
+        ``FetchService`` and never fail initialization.  No new Iceberg
+        snapshot is created.
+        """
         from ...application.services.fetch import FetchService
         from ...infrastructure.progress import progress_callback
 

--- a/src/dbport/application/services/fetch.py
+++ b/src/dbport/application/services/fetch.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
 
 from ...domain.entities.dataset import DatasetKey
 from ...domain.ports.catalog import ICatalog
@@ -32,6 +35,6 @@ class FetchService:
                     table_address,
                     {"dbport.last_fetched_at": ts_str},
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to update last_fetched_at: %s", exc)
         return now

--- a/tests/test_dbport/adapters/primary/test_contract.py
+++ b/tests/test_dbport/adapters/primary/test_contract.py
@@ -1,0 +1,515 @@
+"""Contract tests — lock the public DBPort surface for 0.1.0.
+
+These tests exist to prevent accidental changes to the public API.
+Any change that breaks a test here is a signal that the public contract
+is shifting and must be reviewed deliberately.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module-level exports
+# ---------------------------------------------------------------------------
+
+
+class TestModuleExports:
+    def test_all_contains_only_dbport(self):
+        import dbport
+
+        assert dbport.__all__ == ["DBPort"]
+
+    def test_dbport_importable(self):
+        from dbport import DBPort  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Constructor signature
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorSignature:
+    def test_positional_params(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.__init__)
+        params = list(sig.parameters.values())
+        # Skip 'self'
+        positional = [
+            p for p in params if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and p.name != "self"
+        ]
+        assert [p.name for p in positional] == ["agency", "dataset_id"]
+        for p in positional:
+            assert p.default is inspect.Parameter.empty, f"{p.name} should be required"
+
+    def test_keyword_only_params(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.__init__)
+        kw_only = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if p.kind == inspect.Parameter.KEYWORD_ONLY
+        }
+
+        expected = {
+            "catalog_uri": None,
+            "catalog_token": None,
+            "warehouse": None,
+            "s3_endpoint": None,
+            "s3_access_key": None,
+            "s3_secret_key": None,
+            "duckdb_path": None,
+            "lock_path": None,
+            "model_root": None,
+            "load_inputs_on_init": True,
+            "config_only": False,
+        }
+        assert kw_only == expected
+
+    def test_total_parameter_count(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.__init__)
+        # 13 params + self = 14
+        assert len(sig.parameters) == 14
+
+
+# ---------------------------------------------------------------------------
+# Public method and property inventory
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSurface:
+    def test_public_methods(self):
+        from dbport import DBPort
+
+        expected_methods = {
+            "schema",
+            "load",
+            "execute",
+            "publish",
+            "close",
+            "configure_input",
+            "run",
+        }
+        actual = {
+            name
+            for name in dir(DBPort)
+            if not name.startswith("_") and callable(getattr(DBPort, name))
+        }
+        assert actual == expected_methods
+
+    def test_public_properties(self):
+        from dbport import DBPort
+
+        expected_properties = {"run_hook"}
+        actual = {
+            name
+            for name in dir(DBPort)
+            if not name.startswith("_") and isinstance(getattr(DBPort, name), property)
+        }
+        assert actual == expected_properties
+
+    def test_context_manager_protocol(self):
+        from dbport import DBPort
+
+        assert hasattr(DBPort, "__enter__")
+        assert hasattr(DBPort, "__exit__")
+
+    def test_columns_attribute_set_on_init(self, tmp_path: Path):
+        from dbport import DBPort
+
+        client = DBPort(
+            agency="test",
+            dataset_id="ds",
+            lock_path=str(tmp_path / "dbport.lock"),
+            duckdb_path=str(tmp_path / "test.duckdb"),
+            config_only=True,
+        )
+        assert hasattr(client, "columns")
+
+
+# ---------------------------------------------------------------------------
+# Method signatures
+# ---------------------------------------------------------------------------
+
+
+class TestMethodSignatures:
+    def test_load_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.load)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {
+            "table_address": inspect.Parameter.empty,
+            "filters": None,
+            "version": None,
+        }
+
+    def test_configure_input_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.configure_input)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {
+            "table_address": inspect.Parameter.empty,
+            "filters": None,
+            "version": None,
+        }
+
+    def test_publish_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.publish)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {
+            "version": inspect.Parameter.empty,
+            "params": None,
+            "mode": None,
+        }
+
+    def test_run_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.run)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {
+            "version": None,
+            "mode": None,
+        }
+
+    def test_schema_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.schema)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {"ddl_or_path": inspect.Parameter.empty}
+
+    def test_execute_signature(self):
+        from dbport import DBPort
+
+        sig = inspect.signature(DBPort.execute)
+        params = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name != "self"
+        }
+        assert params == {"sql_or_path": inspect.Parameter.empty}
+
+
+# ---------------------------------------------------------------------------
+# config_only mode contract
+# ---------------------------------------------------------------------------
+
+
+class TestConfigOnlyContract:
+    """Verify which methods are guarded and which work in config_only mode."""
+
+    def _make_config_only(self, tmp_path: Path):
+        from dbport import DBPort
+
+        return DBPort(
+            agency="test",
+            dataset_id="ds",
+            lock_path=str(tmp_path / "dbport.lock"),
+            duckdb_path=str(tmp_path / "test.duckdb"),
+            config_only=True,
+        )
+
+    @pytest.mark.parametrize("method", [
+        "schema",
+        "load",
+        "execute",
+        "configure_input",
+        "run",
+        "publish",
+    ])
+    def test_guarded_methods_raise_runtime_error(self, tmp_path: Path, method: str):
+        client = self._make_config_only(tmp_path)
+        with pytest.raises(RuntimeError, match="config_only"):
+            # All guarded methods need at least one arg
+            if method == "publish":
+                getattr(client, method)(version="v1")
+            elif method in ("load", "configure_input"):
+                getattr(client, method)("some.table")
+            elif method == "schema":
+                getattr(client, method)("CREATE TABLE t (id INT)")
+            elif method == "execute":
+                getattr(client, method)("SELECT 1")
+            elif method == "run":
+                getattr(client, method)()
+        client.close()
+
+    def test_columns_meta_works_in_config_only(self, tmp_path: Path):
+        client = self._make_config_only(tmp_path)
+        client.columns.geo.meta(codelist_id="GEO")
+        client.close()
+
+    def test_columns_attach_works_in_config_only(self, tmp_path: Path):
+        client = self._make_config_only(tmp_path)
+        client.columns.geo.attach(table="test.cl_geo")
+        client.close()
+
+    def test_close_works_in_config_only(self, tmp_path: Path):
+        client = self._make_config_only(tmp_path)
+        client.close()  # should not raise
+
+    def test_context_manager_works_in_config_only(self, tmp_path: Path):
+        from dbport import DBPort
+
+        with DBPort(
+            agency="test",
+            dataset_id="ds",
+            lock_path=str(tmp_path / "dbport.lock"),
+            duckdb_path=str(tmp_path / "test.duckdb"),
+            config_only=True,
+        ) as port:
+            assert port is not None
+
+    def test_run_hook_works_in_config_only(self, tmp_path: Path):
+        client = self._make_config_only(tmp_path)
+        # run_hook is a property that reads from lock — should work
+        hook = client.run_hook
+        assert hook is None or isinstance(hook, str)
+        client.close()
+
+    def test_no_data_dir_created(self, tmp_path: Path):
+        data_dir = tmp_path / "data"
+        self._make_config_only(tmp_path)
+        # duckdb_path is tmp_path/test.duckdb (not in data/), check data/ not created
+        assert not data_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+
+class TestReturnTypes:
+    def _make_full_client(self, tmp_path: Path):
+        import os
+
+        from dbport import DBPort
+
+        creds = {
+            "ICEBERG_REST_URI": "https://catalog.example.com",
+            "ICEBERG_CATALOG_TOKEN": "tok",
+            "ICEBERG_WAREHOUSE": "wh",
+        }
+        with patch.dict(os.environ, creds):
+            return DBPort(
+                agency="test",
+                dataset_id="ds",
+                lock_path=str(tmp_path / "dbport.lock"),
+                duckdb_path=str(tmp_path / "test.duckdb"),
+            )
+
+    def test_load_returns_ingest_record(self, tmp_path: Path):
+        from dbport.domain.entities.input import IngestRecord
+
+        client = self._make_full_client(tmp_path)
+        mock_record = IngestRecord(table_address="estat.foo")
+        mock_svc = MagicMock()
+        mock_svc.execute.return_value = mock_record
+        with patch(
+            "dbport.application.services.ingest.IngestService",
+            return_value=mock_svc,
+        ):
+            result = client.load("estat.foo")
+        assert isinstance(result, IngestRecord)
+        client.close()
+
+    def test_configure_input_returns_ingest_record(self, tmp_path: Path):
+        from dbport.domain.entities.input import IngestRecord
+
+        client = self._make_full_client(tmp_path)
+        mock_record = IngestRecord(table_address="estat.foo")
+        mock_svc = MagicMock()
+        mock_svc.configure.return_value = mock_record
+        with patch(
+            "dbport.application.services.ingest.IngestService",
+            return_value=mock_svc,
+        ):
+            result = client.configure_input("estat.foo")
+        assert isinstance(result, IngestRecord)
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Initialization behavior contract
+# ---------------------------------------------------------------------------
+
+
+class TestInitBehavior:
+    def test_full_mode_calls_sync_phases(self, tmp_path: Path):
+        """Full-mode init calls all four sync phases."""
+        import os
+
+        from dbport import DBPort
+
+        creds = {
+            "ICEBERG_REST_URI": "https://catalog.example.com",
+            "ICEBERG_CATALOG_TOKEN": "tok",
+            "ICEBERG_WAREHOUSE": "wh",
+        }
+        with patch.dict(os.environ, creds):
+            with (
+                patch.object(DBPort, "_auto_detect_schema") as mock_auto,
+                patch.object(DBPort, "_sync_output_state") as mock_sync,
+                patch.object(DBPort, "_update_last_fetched") as mock_fetch,
+                patch.object(DBPort, "_load_inputs") as mock_load,
+            ):
+                client = DBPort(
+                    agency="test",
+                    dataset_id="ds",
+                    lock_path=str(tmp_path / "dbport.lock"),
+                    duckdb_path=str(tmp_path / "test.duckdb"),
+                )
+
+        mock_auto.assert_called_once()
+        mock_sync.assert_called_once()
+        mock_fetch.assert_called_once()
+        mock_load.assert_called_once()
+        client.close()
+
+    def test_load_inputs_on_init_false_skips_input_loading(self, tmp_path: Path):
+        """load_inputs_on_init=False skips the input reload phase."""
+        import os
+
+        from dbport import DBPort
+
+        creds = {
+            "ICEBERG_REST_URI": "https://catalog.example.com",
+            "ICEBERG_CATALOG_TOKEN": "tok",
+            "ICEBERG_WAREHOUSE": "wh",
+        }
+        with patch.dict(os.environ, creds):
+            with (
+                patch.object(DBPort, "_auto_detect_schema"),
+                patch.object(DBPort, "_sync_output_state"),
+                patch.object(DBPort, "_update_last_fetched"),
+                patch.object(DBPort, "_load_inputs") as mock_load,
+            ):
+                client = DBPort(
+                    agency="test",
+                    dataset_id="ds",
+                    lock_path=str(tmp_path / "dbport.lock"),
+                    duckdb_path=str(tmp_path / "test.duckdb"),
+                    load_inputs_on_init=False,
+                )
+
+        mock_load.assert_not_called()
+        client.close()
+
+    def test_config_only_skips_all_sync(self, tmp_path: Path):
+        """config_only=True skips all sync phases and adapter creation."""
+        from dbport import DBPort
+
+        with (
+            patch.object(DBPort, "_auto_detect_schema") as mock_auto,
+            patch.object(DBPort, "_sync_output_state") as mock_sync,
+            patch.object(DBPort, "_update_last_fetched") as mock_fetch,
+            patch.object(DBPort, "_load_inputs") as mock_load,
+        ):
+            client = DBPort(
+                agency="test",
+                dataset_id="ds",
+                lock_path=str(tmp_path / "dbport.lock"),
+                duckdb_path=str(tmp_path / "test.duckdb"),
+                config_only=True,
+            )
+
+        mock_auto.assert_not_called()
+        mock_sync.assert_not_called()
+        mock_fetch.assert_not_called()
+        mock_load.assert_not_called()
+        client.close()
+
+    def test_sync_errors_do_not_fail_init(self, tmp_path: Path):
+        """Errors in sync phases are swallowed; init completes."""
+        import os
+
+        from dbport import DBPort
+
+        creds = {
+            "ICEBERG_REST_URI": "https://catalog.example.com",
+            "ICEBERG_CATALOG_TOKEN": "tok",
+            "ICEBERG_WAREHOUSE": "wh",
+        }
+        with patch.dict(os.environ, creds):
+            with (
+                patch.object(
+                    DBPort, "_auto_detect_schema", side_effect=RuntimeError("boom")
+                ),
+                patch.object(DBPort, "_sync_output_state"),
+                patch.object(DBPort, "_update_last_fetched"),
+                patch.object(DBPort, "_load_inputs"),
+            ):
+                # _auto_detect_schema is called directly (not wrapped in try/except
+                # at this level), but the method itself has a try/except.
+                # Instead, test that the real method swallows errors.
+                pass
+
+        # Test the real private methods with injected failures
+        from dbport.adapters.secondary.compute.duckdb import DuckDBComputeAdapter
+        from dbport.adapters.secondary.lock.toml import TomlLockAdapter
+        from dbport.domain.entities.dataset import Dataset
+
+        client = DBPort.__new__(DBPort)
+        client._compute = DuckDBComputeAdapter(tmp_path / "test.duckdb")
+        client._lock = TomlLockAdapter(
+            tmp_path / "dbport.lock",
+            model_key="test.ds",
+            model_root=".",
+            duckdb_path=str(tmp_path / "test.duckdb"),
+        )
+        client._catalog = MagicMock()
+        client._dataset = Dataset(
+            agency="test",
+            dataset_id="ds",
+            duckdb_path=str(tmp_path / "test.duckdb"),
+            lock_path=str(tmp_path / "dbport.lock"),
+            model_root=str(tmp_path),
+        )
+
+        # Each should swallow errors
+        with patch("dbport.application.services.auto_schema.AutoSchemaService") as m:
+            m.return_value.execute.side_effect = RuntimeError("fail")
+            client._auto_detect_schema()  # should not raise
+
+        with patch("dbport.application.services.sync.SyncService") as m:
+            m.return_value.sync_output_table.side_effect = RuntimeError("fail")
+            client._sync_output_state()  # should not raise
+
+        with patch("dbport.application.services.sync.SyncService") as m:
+            m.return_value.sync_inputs.side_effect = RuntimeError("fail")
+            client._load_inputs()  # should not raise
+
+        client._compute.close()


### PR DESCRIPTION
## Summary

This PR freezes the public `DBPort` API surface for the 0.0.4 release and completes the Python API reference documentation. It adds 33 contract tests that validate the public interface, documents all initialization behavior and parameters, and stabilizes startup semantics.

## Key Changes

### Contract Tests (`tests/test_dbport/adapters/primary/test_contract.py`)
- **Module exports** — validates `__all__` contains only `DBPort`
- **Constructor signature** — locks positional parameters (`agency`, `dataset_id`) and 11 keyword-only parameters with their defaults
- **Public surface inventory** — verifies 7 public methods (`schema`, `load`, `execute`, `publish`, `close`, `configure_input`, `run`) and 1 property (`run_hook`)
- **Method signatures** — validates parameter names and defaults for all public methods
- **`config_only` mode guards** — confirms all data methods raise `RuntimeError` when called in config-only mode, while metadata methods (`.meta()`, `.attach()`) and `.close()` work normally
- **Return types** — validates `load()` and `configure_input()` return `IngestRecord`
- **Initialization behavior** — tests that full mode runs all four sync phases, `load_inputs_on_init=False` skips input reload, `config_only=True` skips all sync, and sync errors never fail initialization

### Documentation (`docs/api/python.md`)
- Added **Quick Reference** table at top listing all methods and their purpose
- Documented all 13 constructor parameters including `model_root`, `load_inputs_on_init`, and `config_only`
- Added **Initialization behavior** section describing the four phases (path resolution, credential resolution, adapter wiring, state sync) with error guarantees
- Added **Full mode vs. `config_only`** comparison table showing which features work in each mode
- Documented `configure_input()` method and its relationship to `load()`
- Documented `run()` method with hook resolution order and dispatch-by-extension rules
- Documented `run_hook` property
- Restructured page with consistent method signature template: parameters → returns → raises → examples
- Added **Complete example** showing full workflow

### Client Implementation (`src/dbport/adapters/primary/client.py`)
- Added comprehensive docstring to `__init__` documenting the four initialization phases and `config_only` behavior
- Added docstrings to `_auto_detect_schema()` explaining when it runs and error handling

### Metadata
- Updated `pyproject.toml` version to `0.0.4`
- Updated `docs/changelog.md` with 0.0.4 release notes
- Updated `docs/backlog.md` marking DBP-DOC-001, DBP-API-001, and DBP-API-002 as done

## Notable Implementation Details

- Contract tests use `inspect.signature()` to validate exact parameter names, kinds, and defaults — any accidental API change will immediately fail tests
- Tests verify both positive cases (methods work) and negative cases (`config_only` guards raise `RuntimeError`)
- Initialization behavior tests use mocking to verify which sync phases are called under different configurations
- Error resilience tests confirm that sync phase failures are logged but never prevent initialization from completing
- Documentation uses consistent structure across all methods for discoverability and maintainability

https://claude.ai/code/session_011eYiur2zG4jYurmwmrm9eQ