### PR TITLE
Complete 0.0.8: Zensical navigation and brand alignment

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -520,48 +520,29 @@ Status: `done`
 
 ## Work Package 0.0.8
 
-Theme: Zensical navigation model.
+Theme: Zensical navigation model and brand alignment.
 
-### DBP-ZEN-001 - Restore the intended left sidebar on the homepage
+Status: `done`
 
-- Priority: `P1`
-- Status: `todo`
-- Files:
-  - `docs/index.md`
-- Required changes:
-  - Remove `hide: navigation` from the homepage
-  - Reconsider whether `hide: toc` should remain
-- Relevant Zensical docs:
-  - [Navigation](https://zensical.org/docs/setup/navigation/)
-- Acceptance criteria:
-  - The homepage participates in the main docs navigation model
+### What was implemented
 
-### DBP-ZEN-002 - Expand left navigation by default
+- **Homepage left sidebar restored** — removed `hide: navigation` from `docs/index.md`; `hide: toc` retained (homepage is a card grid, not long-form content; revisited in DBP-UI-004)
+- **Left navigation expanded** — added `navigation.expand` to `zensical.toml` features so section subpages are visible by default
+- **Right sidebar TOC preserved** — confirmed `toc.integrate` is not enabled and `toc.follow` remains active; the three-column layout (tabs + left nav + right TOC) is intentional
+- **Brand palette applied** — switched named palette from `deep purple`/`amber` to `indigo`/`deep-orange` as base; added `docs/stylesheets/brand.css` with exact brand color overrides (Harbor Blue `#1F4E79`, Signal Coral `#E07A5F`, dark mode backgrounds) via documented `--md-*` custom properties
+- **Brand typography configured** — added `[project.theme.font]` with Inter (text) and JetBrains Mono (code), matching `docs/brand.md`
+- **Zensical-native constraint enforced** — all changes use only documented Zensical/Material capabilities: `extra_css`, `--md-*` properties, `theme.font`, `theme.palette`; no custom template overrides or JavaScript
 
-- Priority: `P1`
-- Status: `todo`
-- Files:
-  - `zensical.toml`
-- Required changes:
-  - Add `navigation.expand`
-- Relevant Zensical docs:
-  - [Navigation](https://zensical.org/docs/setup/navigation/)
-- Acceptance criteria:
-  - Section subpages are visible by default in the left sidebar on desktop
+### Items delivered
 
-### DBP-ZEN-004 - Keep right sidebar TOC instead of integrating it into the left nav
-
-- Priority: `P1`
-- Status: `todo`
-- Files:
-  - `zensical.toml`
-- Required changes:
-  - Explicitly avoid `toc.integrate`
-  - Preserve `toc.follow`
-- Relevant Zensical docs:
-  - [Navigation](https://zensical.org/docs/setup/navigation/)
-- Acceptance criteria:
-  - The docs keep the intended tabs + left nav + right TOC layout
+| Item | Priority | Summary |
+|---|---|---|
+| DBP-ZEN-001 | `P1` | Homepage participates in the main navigation model |
+| DBP-ZEN-002 | `P1` | Section subpages visible by default in the left sidebar |
+| DBP-ZEN-004 | `P1` | Three-column layout (tabs + left nav + right TOC) explicitly preserved |
+| DBP-UI-005 | `P2` | Brand palette (Harbor Blue / Signal Coral) applied via custom CSS overrides |
+| DBP-UI-006 | `P2` | Brand typography (Inter / JetBrains Mono) configured via theme font settings |
+| DBP-UI-007 | `P1` | All changes verified against documented Zensical capabilities |
 
 ---
 
@@ -879,6 +860,6 @@ This roadmap is complete when the repository is ready for its first public relea
 - `0.0.5` freezes the CLI contract, including command taxonomy, model/version resolution, and operational error behavior
 - `0.0.6` locks down the public package surface, completes PyPI-facing package metadata, establishes the public repository posture, and makes public-facing documentation trustworthy
 - `0.0.7` makes execution, hook, publish, and lock-file semantics stable enough for a safety-oriented first release
-- `0.0.8` implements the intended Zensical navigation model
+- `0.0.8` implements the intended Zensical navigation model and aligns the theme with the brand guide
 - `0.0.9` makes the homepage publication-ready
 - `0.1.0` delivers the first public release to PyPI and GitHub Pages with deterministic credentials, verified package artifacts, enforced CI quality gates, and release-gated examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 hide:
-  - navigation
   - toc
 ---
 

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,22 @@
+/* DBPort brand color overrides — see docs/brand.md for design tokens.
+   Uses only documented --md-* custom properties (Material/Zensical). */
+
+/* ---------- Light mode ---------- */
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #1F4E79;          /* Harbor Blue */
+  --md-primary-fg-color--light: #4F7EA8;   /* Tide Blue */
+  --md-primary-fg-color--dark: #16354F;    /* Deep Current */
+  --md-accent-fg-color: #E07A5F;           /* Signal Coral */
+}
+
+/* ---------- Dark mode ---------- */
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #4F7EA8;          /* Tide Blue — lighter for dark bg */
+  --md-primary-fg-color--light: #6A9BC4;
+  --md-primary-fg-color--dark: #1F4E79;    /* Harbor Blue */
+  --md-accent-fg-color: #E07A5F;           /* Signal Coral */
+  --md-default-bg-color: #0F1C28;          /* Brand dark background */
+  --md-default-bg-color--light: #16354F;   /* Deep Current — cards/panels */
+}

--- a/docs/versions/changelog.md
+++ b/docs/versions/changelog.md
@@ -6,6 +6,29 @@ Each entry includes: version number, release date, and a summary of changes grou
 
 ---
 
+## 0.0.8 — 2026-03-17
+
+Zensical navigation model and brand alignment.
+
+### Changed
+
+- **Homepage navigation restored** — removed `hide: navigation` from the homepage so the left sidebar is visible on all pages, including the landing page
+- **Left navigation expanded by default** — added `navigation.expand` so section subpages are visible in the sidebar without clicking to expand
+- **Brand palette applied** — switched theme palette from `deep purple`/`amber` to brand-aligned `indigo`/`deep-orange` base, with exact brand color overrides via `docs/stylesheets/brand.css` (Harbor Blue `#1F4E79`, Signal Coral `#E07A5F`, dark mode backgrounds from brand guide)
+- **Brand typography configured** — set Inter as the text font and JetBrains Mono as the code font via `[project.theme.font]`, matching `docs/brand.md`
+
+### Added
+
+- **`docs/stylesheets/brand.css`** — custom property overrides for light and dark mode using the brand design tokens from `docs/brand.md`
+
+### Confirmed
+
+- **Right sidebar TOC preserved** — explicitly confirmed `toc.integrate` is not enabled and `toc.follow` remains active, keeping the intended three-column layout (tabs + left nav + right TOC)
+- **Logo unchanged** — `lucide/fishing-hook` icon matches the brand guide; no change needed
+- **Zensical-native only** — all changes use documented Zensical/Material capabilities (`extra_css`, `--md-*` properties, `theme.font`); no custom template overrides or JavaScript
+
+---
+
 ## 0.0.7 — 2026-03-17
 
 Execution model and conceptual docs depth.

--- a/docs/versions/roadmap.md
+++ b/docs/versions/roadmap.md
@@ -17,7 +17,7 @@ For completed work, see the [Changelog](changelog.md).
 | 0.0.5 | CLI reference and executable workflows | Done |
 | 0.0.6 | Public package surface and repository trustworthiness | Done |
 | 0.0.7 | Execution model and conceptual docs depth | Done |
-| 0.0.8 | Zensical navigation model | Planned |
+| 0.0.8 | Zensical navigation model and brand alignment | Done |
 | 0.0.9 | Homepage UX and publication-facing polish | Planned |
 | 0.1.0 | First public release (PyPI + GitHub Pages) | Planned |
 
@@ -58,11 +58,14 @@ For completed work, see the [Changelog](changelog.md).
 - ~~Strengthen section index pages~~
 - ~~Tighten hook execution and publish safety semantics~~
 
-## 0.0.8 — Zensical navigation model
+## 0.0.8 — Zensical navigation model and brand alignment
 
-- Restore the left sidebar on the homepage
-- Expand left navigation by default
-- Keep the right sidebar TOC separate from left nav
+- ~~Restore the left sidebar on the homepage~~
+- ~~Expand left navigation by default~~
+- ~~Keep the right sidebar TOC separate from left nav~~
+- ~~Apply brand palette (Harbor Blue / Signal Coral) via custom CSS~~
+- ~~Configure brand typography (Inter / JetBrains Mono)~~
+- ~~Verify all changes use only documented Zensical capabilities~~
 
 ## 0.0.9 — Homepage UX and publication-facing polish
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbport"
-version = "0.0.7"
+version = "0.0.8"
 description = "DuckDB-native runtime for building reproducible warehouse datasets"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/zensical.toml
+++ b/zensical.toml
@@ -7,6 +7,8 @@ repo_name = "knifflig/dbport"
 
 copyright = "Copyright &copy; 2026 knifflig"
 
+extra_css = ["stylesheets/brand.css"]
+
 nav = [
     { "Home" = "index.md" },
     { "Getting Started" = [
@@ -58,6 +60,7 @@ features = [
     "navigation.tabs",
     "navigation.tabs.sticky",
     "navigation.top",
+    "navigation.expand",
     "navigation.tracking",
     "search.highlight",
     "toc.follow",
@@ -65,17 +68,21 @@ features = [
 
 [[project.theme.palette]]
 scheme = "default"
-primary = "deep purple"
-accent = "amber"
+primary = "indigo"
+accent = "deep-orange"
 toggle.icon = "lucide/sun"
 toggle.name = "Switch to dark mode"
 
 [[project.theme.palette]]
 scheme = "slate"
-primary = "deep purple"
-accent = "amber"
+primary = "indigo"
+accent = "deep-orange"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
+
+[project.theme.font]
+text = "Inter"
+code = "JetBrains Mono"
 
 [project.theme.icon]
 logo = "lucide/fishing-hook"


### PR DESCRIPTION
## Summary

Completes work package 0.0.8 by implementing the Zensical navigation model and aligning the documentation theme with the brand guide. All changes use only documented Zensical/Material capabilities without custom template overrides or JavaScript.

## Key Changes

- **Homepage navigation restored** — removed `hide: navigation` from `docs/index.md` so the left sidebar is visible on all pages, including the landing page
- **Left navigation expanded by default** — added `navigation.expand` feature to `zensical.toml` so section subpages are visible in the sidebar without requiring expansion clicks
- **Brand palette applied** — switched theme palette from `deep purple`/`amber` to `indigo`/`deep-orange` base colors, with exact brand color overrides via new `docs/stylesheets/brand.css` (Harbor Blue `#1F4E79`, Signal Coral `#E07A5F`, dark mode backgrounds)
- **Brand typography configured** — added `[project.theme.font]` section to `zensical.toml` with Inter (text) and JetBrains Mono (code) fonts, matching `docs/brand.md`
- **Right sidebar TOC preserved** — explicitly confirmed `toc.integrate` is not enabled and `toc.follow` remains active, maintaining the intended three-column layout (tabs + left nav + right TOC)
- **Version bumped** — updated `pyproject.toml` to `0.0.8` and added changelog entry documenting all changes

## Implementation Details

- All color overrides use documented `--md-*` custom properties for both light (`default`) and dark (`slate`) color schemes
- Brand CSS is loaded via `extra_css` configuration, keeping changes isolated and maintainable
- No modifications to templates, JavaScript, or undocumented Material/Zensical features
- Backlog and roadmap updated to reflect completion of DBP-ZEN-001, DBP-ZEN-002, DBP-ZEN-004, DBP-UI-005, DBP-UI-006, and DBP-UI-007

https://claude.ai/code/session_01EYaLMjHUB2pA85UUi4wDTC