### PR TITLE
v0.0.9: Homepage redesign and Zensical docs polish

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -550,10 +550,12 @@ Status: `done`
 
 Theme: homepage UX and publication-facing docs polish.
 
+Status: `done`
+
 ### DBP-ZEN-010 - Apply stronger Zensical teaching patterns to core concept pages
 
 - Priority: `P2`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/concepts/lock-file.md`
   - other concept pages as needed
@@ -575,7 +577,7 @@ Theme: homepage UX and publication-facing docs polish.
 ### DBP-UI-001 - Redesign the homepage card grid to fit clean rows
 
 - Priority: `P1`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/index.md`
 - Required changes:
@@ -590,7 +592,7 @@ Theme: homepage UX and publication-facing docs polish.
 ### DBP-UI-002 - Improve card interaction without unsupported hacks
 
 - Priority: `P1`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/index.md`
 - Required changes:
@@ -606,7 +608,7 @@ Theme: homepage UX and publication-facing docs polish.
 ### DBP-UI-003 - Make the homepage more documentation-first
 
 - Priority: `P1`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/index.md`
 - Required changes:
@@ -622,7 +624,7 @@ Theme: homepage UX and publication-facing docs polish.
 ### DBP-UI-004 - Review homepage TOC behavior
 
 - Priority: `P2`
-- Status: `todo`
+- Status: `done`
 - Files:
   - `docs/index.md`
 - Required changes:
@@ -631,6 +633,16 @@ Theme: homepage UX and publication-facing docs polish.
   - [Navigation](https://zensical.org/docs/setup/navigation/)
 - Acceptance criteria:
   - Homepage sidebar behavior is intentional and consistent with the page content
+
+### Items delivered
+
+| Item | Priority | Summary |
+|---|---|---|
+| DBP-ZEN-010 | `P2` | Lock file page enhanced with code annotations, warning admonition, and tip admonition |
+| DBP-UI-001 | `P1` | Homepage expanded from 4 to 6 cards aligned to the docs IA |
+| DBP-UI-002 | `P1` | Cards use documentation-first descriptions with clear action links |
+| DBP-UI-003 | `P1` | Marketing copy and feature list removed; homepage is now a documentation hub |
+| DBP-UI-004 | `P2` | `hide: toc` confirmed as intentional for the card-grid homepage |
 
 ---
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -29,12 +29,14 @@ DBPort supports hook-based execution for model logic. A hook is a Python or SQL 
 
 ## Hook resolution order
 
-When no explicit target is given, DBPort resolves the hook in this order:
+!!! note "Resolution precedence"
 
-1. **Configured hook path** — set via `dbp config default hook`
-2. **`main.py`** in the model root — auto-detected if it exists
-3. **`sql/main.sql`** in the model root — legacy fallback
-4. **Default `main.py`** — used when no model root is available; errors at execution if the file does not exist
+    When no explicit target is given, DBPort resolves the hook in this order:
+
+    1. **Configured hook path** — set via `dbp config default hook`
+    2. **`main.py`** in the model root — auto-detected if it exists
+    3. **`sql/main.sql`** in the model root — legacy fallback
+    4. **Default `main.py`** — used when no model root is available; errors at execution if the file does not exist
 
 ## Python hooks
 
@@ -107,4 +109,6 @@ These three operations are distinct and composable:
 
 ## Trust model
 
-Hook files are trusted code. They run with the same permissions as the calling script or CLI process. There is no sandboxing — the hook is your model logic, authored by the model owner. This is the same trust boundary as any other user-authored Python module.
+!!! warning "Hooks are trusted code"
+
+    Hook files run with the same permissions as the calling script or CLI process. There is no sandboxing — the hook is your model logic, authored by the model owner. This is the same trust boundary as any other user-authored Python module.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -17,9 +17,14 @@ Start with [Inputs & Loading](inputs.md) if you want to understand data flow, or
 
 ## The mental model
 
-```
-Warehouse ──▶ dbp model load ──▶ DuckDB ──▶ dbp model exec ──▶ dbp model publish ──▶ Warehouse
-              (inputs)           (your SQL/Python)                (versioned output)
+``` mermaid
+graph LR
+    A["Warehouse"] -->|"dbp model load"| B["DuckDB"]
+    B -->|"dbp model exec"| B
+    B -->|"dbp model publish"| C["Warehouse"]
+    style A fill:#f5f5f5,stroke:#1F4E79
+    style B fill:#f5f5f5,stroke:#E07A5F
+    style C fill:#f5f5f5,stroke:#1F4E79
 ```
 
 You bring the model. DBPort manages the dataset lifecycle.

--- a/docs/concepts/inputs.md
+++ b/docs/concepts/inputs.md
@@ -44,39 +44,31 @@ Filters are equality predicates pushed down to the Iceberg scan. They reduce the
 
 Each Iceberg table has a snapshot ID. If the snapshot has not changed since the last run and the DuckDB table already exists, loading is skipped automatically.
 
-This makes repeated runs fast without manual cache management. To force re-resolution of the newest snapshot:
+This makes repeated runs fast without manual cache management.
 
-=== "CLI"
+!!! tip "Forcing a fresh snapshot check"
 
-    ```bash
-    dbp model load --update
-    ```
-
-=== "Python"
-
-    ```python
-    # Snapshot caching is automatic — just call load() again.
-    # The table is only re-loaded if the warehouse snapshot changed.
-    port.load("estat.nama_10r_3empers")
-    ```
+    Use `dbp model load --update` (CLI) to re-resolve the newest snapshot even when the cached snapshot ID has not changed. In Python, snapshot caching is automatic — calling `port.load()` again only re-loads if the warehouse snapshot actually changed.
 
 ## How ingestion works
 
-Under the hood, loading uses pyiceberg's Arrow C++ multi-threaded Parquet reader:
+Under the hood, loading uses pyiceberg's Arrow C++ multi-threaded Parquet reader. No full-table Python memory allocation — data streams directly from Parquet to DuckDB.
 
-1. pyiceberg scans the table with the given filters and snapshot
-2. A `RecordBatchReader` streams Arrow batches into DuckDB
-3. DuckDB creates (or replaces) the table from the Arrow stream
-
-No full-table Python memory allocation — data streams directly from Parquet to DuckDB.
+``` mermaid
+graph LR
+    A["Iceberg table<br/>(Parquet files)"] -->|"pyiceberg scan<br/>+ filters"| B["RecordBatchReader<br/>(Arrow batches)"]
+    B -->|"streaming insert"| C["DuckDB table<br/>(local file)"]
+```
 
 ## Input tracking
 
-Every load is recorded in `dbport.lock`:
+!!! info "What gets recorded in `dbport.lock`"
 
-- Table address
-- Filters applied
-- Snapshot ID and timestamp
-- Row count
+    Every load records the following in the lock file:
 
-This state is included in published metadata and enables the snapshot-based skip logic on subsequent runs.
+    - **Table address** — the fully qualified Iceberg table name
+    - **Filters applied** — equality predicates used during the scan
+    - **Snapshot ID and timestamp** — pins the exact data version loaded
+    - **Row count** — number of rows ingested
+
+    This state is included in published metadata and enables the snapshot-based skip logic on subsequent runs.

--- a/docs/concepts/lock-file.md
+++ b/docs/concepts/lock-file.md
@@ -13,6 +13,45 @@ The lock file lives at the **repository root**, next to `pyproject.toml`. When n
 - **Multi-model** — each model gets a namespaced section under `[models."agency.dataset_id"]`
 - **Safe to commit** — belongs in version control
 
+## Annotated example
+
+``` toml
+default_model = "wifor.emp__regional_trends" # (1)!
+
+[models."wifor.emp__regional_trends"] # (2)!
+last_fetched_at = "2026-03-15T08:00:00Z"
+
+[models."wifor.emp__regional_trends".schema]
+ddl = "CREATE OR REPLACE TABLE wifor.emp__regional_trends (nuts2024 VARCHAR, year SMALLINT, value DOUBLE)" # (3)!
+
+[[models."wifor.emp__regional_trends".schema.columns]] # (4)!
+column_name  = "nuts2024"
+column_pos   = 0
+codelist_id  = "NUTS2024"
+codelist_kind = "hierarchical"
+attach_table = "wifor.cl_nuts2024"
+
+[[models."wifor.emp__regional_trends".inputs]] # (5)!
+table_address    = "estat.nama_10r_3empers"
+filters          = {wstatus = "EMP"}
+last_snapshot_id = 123456789
+rows_loaded      = 42000
+
+[[models."wifor.emp__regional_trends".versions]] # (6)!
+version      = "2026-03-09"
+published_at = "2026-03-09T14:30:00Z"
+params       = {wstatus = "EMP"}
+rows         = 1345678
+completed    = true
+```
+
+1. Which model the CLI uses when no `--model` flag is given.
+2. Each model is namespaced by `agency.dataset_id`.
+3. The exact DDL that DuckDB executes — must match the current `.sql` file.
+4. Column metadata entries. Set via `port.columns.<name>.meta()` or `dbp config model … columns`.
+5. One entry per loaded input table. `last_snapshot_id` drives the ingest cache.
+6. Append-only version history. Each `publish()` adds a new entry.
+
 ## When does the lock file change?
 
 Every mutating operation writes to disk immediately — there is no deferred flush.
@@ -84,13 +123,27 @@ Normal development produces predictable diffs. Here are the three most common pa
 +completed    = true
 ```
 
+## Fields that matter for correctness
+
+Most fields are informational, but three have behavioral consequences.
+
+!!! warning "These fields drive runtime behavior"
+
+    - **`last_snapshot_id`** — drives the ingest cache. A wrong value causes stale data or unnecessary reloads.
+    - **`completed`** on versions — drives publish idempotency. Flipping this causes skipped or duplicate publishes.
+    - **`ddl`** — must match what DuckDB actually has. Use the schema command to change it, not manual edits.
+
+    If any of these are wrong, the safest fix is to delete the lock file and re-run the full pipeline. The warehouse is always the source of truth.
+
 ## Merge conflicts
 
 The lock file is structured to minimize conflicts:
 
-- **`[[versions]]`** — append-only. Accept both sides; each publish appends a new entry.
-- **`[schema]`** — take the version that matches the current DDL in your SQL file. If both sides changed the DDL, resolve the DDL first, then re-run the schema command.
-- **`[[inputs]]`** — take the entry with the higher `last_snapshot_id`. The next load will re-check against the warehouse regardless.
+!!! tip "Resolution by section"
+
+    - **`[[versions]]`** — append-only. Accept both sides; each publish appends a new entry.
+    - **`[schema]`** — take the version that matches the current DDL in your SQL file. If both sides changed the DDL, resolve the DDL first, then re-run the schema command.
+    - **`[[inputs]]`** — take the entry with the higher `last_snapshot_id`. The next load will re-check against the warehouse regardless.
 
 ## Stale or missing lock file
 
@@ -146,14 +199,6 @@ Running the full pipeline rebuilds all lock state from scratch. The warehouse is
         port.execute("sql/transform.sql")
         port.publish(version="2026-03-15", params={"wstatus": "EMP"})
     ```
-
-## Fields that matter for correctness
-
-Most fields are informational, but three have behavioral consequences:
-
-- **`last_snapshot_id`** — drives the ingest cache; a wrong value causes stale data or unnecessary reloads
-- **`completed`** on versions — drives publish idempotency; flipping this causes skipped or duplicate publishes
-- **`ddl`** — must match what DuckDB actually has; use the schema command to change it
 
 ## Multi-model support
 

--- a/docs/concepts/metadata.md
+++ b/docs/concepts/metadata.md
@@ -67,9 +67,13 @@ The referenced table should already be loaded via `dbp model load` or `port.load
 In the Python API, `.meta()` returns `self` for chaining:
 
 ```python
-port.columns.nuts2024.meta(codelist_id="NUTS2024").attach(table="wifor.cl_nuts2024")
+port.columns.nuts2024.meta(codelist_id="NUTS2024").attach(table="wifor.cl_nuts2024") # (1)!
 ```
+
+1. `.meta()` returns the `ColumnConfig` instance, so `.attach()` can be called immediately on the result.
 
 ## How metadata is stored
 
-On publish, the finalized `metadata.json` is built in-memory and embedded directly in Iceberg table properties (gzip + base64 compressed). Codelist CSVs are generated in-memory from DuckDB and embedded in Iceberg column docs. No intermediate files are written to disk.
+!!! info "No files on disk"
+
+    On publish, the finalized `metadata.json` is built in-memory and embedded directly in Iceberg table properties (gzip + base64 compressed). Codelist CSVs are generated in-memory from DuckDB and embedded in Iceberg column docs. No intermediate files are written to disk.

--- a/docs/concepts/outputs.md
+++ b/docs/concepts/outputs.md
@@ -34,18 +34,22 @@ The table is created in DuckDB and the schema (DDL + column list) is persisted t
 
 If the output table already exists in the warehouse, DBPort compares the local DDL against the warehouse schema. Incompatible changes raise `SchemaDriftError`:
 
-```
+``` title="SchemaDriftError output"
 SchemaDriftError: Schema drift detected:
-  + new_column (string)     # added locally, not in warehouse
-  - old_column (int32)      # in warehouse, removed locally
-  ~ value (int32 → float64) # type changed
+  + new_column (string)     # (1)!
+  - old_column (int32)      # (2)!
+  ~ value (int32 → float64) # (3)!
 ```
+
+1. Column added locally but not present in the warehouse.
+2. Column exists in the warehouse but was removed from the local DDL.
+3. Column type changed between local and warehouse schema.
 
 This check runs at schema declaration time (early fail-fast) and again at publish time (safety net).
 
-## Idempotency
+!!! info "Idempotent schema declaration"
 
-Declaring the same schema repeatedly is idempotent — the table is created or replaced in DuckDB without error.
+    Declaring the same schema repeatedly is safe — the table is created or replaced in DuckDB without error. Only incompatible changes relative to the *warehouse* trigger `SchemaDriftError`.
 
 ## Column metadata
 

--- a/docs/concepts/versioning.md
+++ b/docs/concepts/versioning.md
@@ -59,11 +59,11 @@ This syncs state, executes the configured hook, and publishes — equivalent to 
 
 ## Pre-publish checks
 
-Before writing any data, publish runs these checks in order:
+!!! warning "These checks must pass before any data is written"
 
-1. **Schema defined** — fails if no schema has been declared
-2. **Version idempotency** — if the version already completed, returns immediately (skipped in refresh mode)
-3. **Schema drift** — compares local schema to warehouse schema; fails with a diff if incompatible. Catalog connection failures also block the publish.
+    1. **Schema defined** — fails if no schema has been declared.
+    2. **Version idempotency** — if the version already completed, returns immediately (skipped in refresh mode).
+    3. **Schema drift** — compares local schema to warehouse schema; fails with a diff if incompatible. Catalog connection failures also block the publish.
 
 ## Idempotency and checkpoints
 
@@ -84,12 +84,16 @@ If a publish is interrupted, the next run detects the incomplete checkpoint and 
 
 ## Write strategy
 
-The DuckDB `iceberg` extension is the primary write path. When the catalog does not support multi-table commits (e.g., returns 404 on the transactions endpoint), the adapter auto-switches to **streaming Arrow fallback**:
+The DuckDB `iceberg` extension is the primary write path.
 
-- Streams 50K-row Arrow batches from DuckDB
-- Each batch committed in a single pyiceberg transaction
-- Checkpoint properties updated per batch
-- On commit conflict: reload metadata, resume from remote checkpoint (max 5 retries)
-- Peak memory: ~50K rows per batch (bounded)
+!!! info "Automatic streaming Arrow fallback"
 
-This session-level fallback is transparent — once DuckDB writes fail, all subsequent writes use Arrow without retrying.
+    When the catalog does not support multi-table commits (e.g., returns 404 on the transactions endpoint), the adapter auto-switches to streaming Arrow:
+
+    - Streams 50K-row Arrow batches from DuckDB
+    - Each batch committed in a single pyiceberg transaction
+    - Checkpoint properties updated per batch
+    - On commit conflict: reload metadata, resume from remote checkpoint (max 5 retries)
+    - Peak memory: ~50K rows per batch (bounded)
+
+    This session-level fallback is transparent — once DuckDB writes fail, all subsequent writes use Arrow without retrying.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,43 +7,59 @@ hide:
 
 **Versioned dataset recomputation on DuckDB, published to Iceberg.**
 
-Analytic workloads often recompute the same large dataset periodically to produce a new version. DBPort handles the lifecycle around that — loading inputs, enforcing schema contracts, tracking versions, and publishing safely — so you can focus on the model.
+Load inputs, enforce schema contracts, track versions, and publish safely — so you can focus on the model.
 
 ---
 
 <div class="grid cards" markdown>
 
--   :material-console:{ .lg .middle } **CLI-driven workflow**
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
 
     ---
 
-    `dbp model run` loads inputs, executes your model, and publishes the result in one command. Configure once, recompute on demand.
+    Install DBPort, configure credentials, and run your first model in five minutes.
 
-    [:octicons-arrow-right-24: Getting started](getting-started/index.md)
+    [:octicons-arrow-right-24: Start here](getting-started/index.md)
 
--   :material-database:{ .lg .middle } **DuckDB-native execution**
-
-    ---
-
-    All data operations run through DuckDB. Tables stream in via Arrow, transforms run in SQL or Python, outputs publish to Iceberg.
-
-    [:octicons-arrow-right-24: Concepts](concepts/index.md)
-
--   :material-shield-check:{ .lg .middle } **Safe, versioned publish**
+-   :material-book-open-variant:{ .lg .middle } **Concepts**
 
     ---
 
-    Schema drift protection, version checkpoints, and resumable writes. Re-running a completed version is always a no-op.
+    How inputs, schemas, metadata, versioning, and the lock file work together.
 
-    [:octicons-arrow-right-24: CLI Reference](api/cli.md)
+    [:octicons-arrow-right-24: Read the concepts](concepts/index.md)
 
--   :material-file-document:{ .lg .middle } **Automatic metadata**
+-   :material-console:{ .lg .middle } **CLI Reference**
 
     ---
 
-    Codelists, version history, and lifecycle timestamps are managed hands-free. No manual metadata files to maintain.
+    Full command reference for `dbp init`, `dbp model`, `dbp config`, and `dbp status`.
 
-    [:octicons-arrow-right-24: Examples](examples/index.md)
+    [:octicons-arrow-right-24: See all commands](api/cli.md)
+
+-   :material-language-python:{ .lg .middle } **Python API**
+
+    ---
+
+    Constructor options, methods, and lifecycle for the `DBPort` class.
+
+    [:octicons-arrow-right-24: See the API](api/python.md)
+
+-   :material-file-code:{ .lg .middle } **Examples**
+
+    ---
+
+    End-to-end CLI and Python workflows showing load, transform, and publish.
+
+    [:octicons-arrow-right-24: View examples](examples/index.md)
+
+-   :material-history:{ .lg .middle } **Changelog**
+
+    ---
+
+    What changed in each release, from `0.0.1` through the current version.
+
+    [:octicons-arrow-right-24: View changelog](changelog.md)
 
 </div>
 
@@ -51,39 +67,29 @@ Analytic workloads often recompute the same large dataset periodically to produc
 
 ## Quick example
 
-```bash
-# Initialize a project
-dbp init regional_trends --agency wifor --dataset emp__regional_trends
-cd regional_trends
+=== "CLI"
 
-# Configure the model
-dbp config model wifor.emp__regional_trends schema sql/create_output.sql
-dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers
+    ```bash
+    # Initialize a project
+    dbp init regional_trends --agency wifor --dataset emp__regional_trends
+    cd regional_trends
 
-# Run the full lifecycle: load → execute → publish
-dbp model run --version 2026-03-09 --timing
-```
+    # Configure the model
+    dbp config model wifor.emp__regional_trends schema sql/create_output.sql
+    dbp config model wifor.emp__regional_trends input estat.nama_10r_3empers
 
-For programmatic control, the same workflow in Python:
+    # Run the full lifecycle: load → execute → publish
+    dbp model run --version 2026-03-09 --timing
+    ```
 
-```python
-from dbport import DBPort
+=== "Python"
 
-with DBPort(agency="wifor", dataset_id="emp__regional_trends") as port:
-    port.schema("sql/create_output.sql")
-    port.load("estat.nama_10r_3empers", filters={"wstatus": "EMP"})
-    port.execute("sql/transform.sql")
-    port.publish(version="2026-03-09", params={"wstatus": "EMP"})
-```
+    ```python
+    from dbport import DBPort
 
----
-
-## Key features
-
-- **CLI-first** — `dbp` covers init, config, load, exec, publish, and run. One command for the full lifecycle.
-- **DuckDB-native** — ingest and publish go through the DuckDB Iceberg extension. No batch loops, no memory copies.
-- **Snapshot-cached ingest** — `dbp model load` skips unchanged tables automatically.
-- **Schema contracts** — publish checks local vs warehouse schema before writing anything.
-- **Idempotent publish** — interrupted runs resume from checkpoint. Completed versions are skipped.
-- **Automatic metadata** — timestamps, input provenance, codelists, and version history — all managed without manual files.
-- **Committable lock file** — `dbport.lock` is TOML, credential-free, and safe to commit.
+    with DBPort(agency="wifor", dataset_id="emp__regional_trends") as port:
+        port.schema("sql/create_output.sql")
+        port.load("estat.nama_10r_3empers", filters={"wstatus": "EMP"})
+        port.execute("sql/transform.sql")
+        port.publish(version="2026-03-09", params={"wstatus": "EMP"})
+    ```

--- a/docs/versions/changelog.md
+++ b/docs/versions/changelog.md
@@ -6,6 +6,23 @@ Each entry includes: version number, release date, and a summary of changes grou
 
 ---
 
+## 0.0.9 — 2026-03-18
+
+Homepage UX and publication-facing docs polish.
+
+### Changed
+
+- **Homepage redesigned** — expanded from 4 to 6 cards aligned to the docs information architecture (Getting Started, Concepts, CLI Reference, Python API, Examples, Changelog); cards use documentation-first descriptions instead of marketing copy
+- **Homepage content trimmed** — removed the "Key features" section; the card grid and quick example now serve as the sole entry points; hero text shortened to a single sentence
+- **Quick example uses content tabs** — CLI and Python examples are now presented in `=== "CLI"` / `=== "Python"` tabs instead of sequential blocks
+- **Homepage TOC kept hidden** — confirmed `hide: toc` is the correct choice for a card-grid landing page (no long-form headings to navigate)
+
+### Improved
+
+- **Lock file page uses Zensical teaching patterns** — added code annotations (`(1)!` syntax) to the annotated TOML example with inline explanations for each section; replaced plain-text correctness warnings with `!!! warning` admonition; replaced merge conflict resolution list with `!!! tip` admonition; improved visual scanability without custom hacks
+
+---
+
 ## 0.0.8 — 2026-03-17
 
 Zensical navigation model and brand alignment.

--- a/docs/versions/changelog.md
+++ b/docs/versions/changelog.md
@@ -20,6 +20,12 @@ Homepage UX and publication-facing docs polish.
 ### Improved
 
 - **Lock file page uses Zensical teaching patterns** — added code annotations (`(1)!` syntax) to the annotated TOML example with inline explanations for each section; replaced plain-text correctness warnings with `!!! warning` admonition; replaced merge conflict resolution list with `!!! tip` admonition; improved visual scanability without custom hacks
+- **Inputs page enhanced** — added Mermaid flow diagram for the Arrow ingestion pipeline; snapshot caching force-refresh note moved to `!!! tip` admonition; input tracking details moved to `!!! info` admonition
+- **Outputs page enhanced** — `SchemaDriftError` example now uses code annotations explaining each diff symbol (`+`, `-`, `~`); idempotency note consolidated into `!!! info` admonition
+- **Metadata page enhanced** — chaining example uses code annotation explaining the return-self pattern; storage mechanism highlighted with `!!! info` admonition
+- **Hooks page enhanced** — hook resolution order wrapped in `!!! note` admonition for reference visibility; trust model wrapped in `!!! warning` admonition for security emphasis
+- **Versioning page enhanced** — pre-publish checks wrapped in `!!! warning` admonition; streaming Arrow fallback wrapped in `!!! info` admonition
+- **Concepts index page enhanced** — ASCII mental model diagram replaced with Mermaid `graph LR` flow diagram using brand colors
 
 ---
 

--- a/docs/versions/roadmap.md
+++ b/docs/versions/roadmap.md
@@ -18,7 +18,7 @@ For completed work, see the [Changelog](changelog.md).
 | 0.0.6 | Public package surface and repository trustworthiness | Done |
 | 0.0.7 | Execution model and conceptual docs depth | Done |
 | 0.0.8 | Zensical navigation model and brand alignment | Done |
-| 0.0.9 | Homepage UX and publication-facing polish | Planned |
+| 0.0.9 | Homepage UX and publication-facing polish | Done |
 | 0.1.0 | First public release (PyPI + GitHub Pages) | Planned |
 
 ---
@@ -69,11 +69,11 @@ For completed work, see the [Changelog](changelog.md).
 
 ## 0.0.9 — Homepage UX and publication-facing polish
 
-- Apply stronger Zensical teaching patterns to core concept pages
-- Redesign the homepage card grid for balanced layout
-- Improve card interaction using supported patterns
-- Make the homepage more documentation-first
-- Review homepage TOC behavior
+- ~~Apply stronger Zensical teaching patterns to core concept pages~~
+- ~~Redesign the homepage card grid for balanced layout~~
+- ~~Improve card interaction using supported patterns~~
+- ~~Make the homepage more documentation-first~~
+- ~~Review homepage TOC behavior~~
 
 ## 0.1.0 — First public release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbport"
-version = "0.0.8"
+version = "0.0.9"
 description = "DuckDB-native runtime for building reproducible warehouse datasets"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary

This release redesigns the DBPort homepage and applies stronger Zensical teaching patterns across core concept pages. The documentation is now more documentation-first and less marketing-focused, with improved visual hierarchy and interactive elements.

## Key Changes

**Homepage Redesign**
- Expanded card grid from 4 to 6 cards aligned to the docs information architecture: Getting Started, Concepts, CLI Reference, Python API, Examples, and Changelog
- Replaced marketing copy with documentation-first descriptions and clear action links
- Removed the "Key features" section; the card grid and quick example now serve as the sole entry points
- Shortened hero text to a single sentence
- Converted quick example to use content tabs (`=== "CLI"` / `=== "Python"`) for side-by-side comparison
- Confirmed `hide: toc` is intentional for the card-grid landing page

**Concept Pages Enhanced with Zensical Patterns**
- **Lock file page**: Added code annotations with inline explanations for each TOML section; replaced plain-text warnings with `!!! warning` admonition; replaced merge conflict resolution list with `!!! tip` admonition
- **Inputs page**: Added Mermaid flow diagram for the Arrow ingestion pipeline; moved snapshot caching force-refresh note to `!!! tip` admonition; moved input tracking details to `!!! info` admonition
- **Outputs page**: Added code annotations explaining `SchemaDriftError` diff symbols (`+`, `-`, `~`); consolidated idempotency note into `!!! info` admonition
- **Metadata page**: Added code annotation explaining the return-self chaining pattern; highlighted storage mechanism with `!!! info` admonition
- **Hooks page**: Wrapped hook resolution order in `!!! note` admonition; wrapped trust model in `!!! warning` admonition for security emphasis
- **Versioning page**: Wrapped pre-publish checks in `!!! warning` admonition; wrapped streaming Arrow fallback in `!!! info` admonition
- **Concepts index page**: Replaced ASCII mental model diagram with Mermaid `graph LR` flow diagram using brand colors

**Version Bump**
- Updated `pyproject.toml` version from `0.0.8` to `0.0.9`
- Added comprehensive changelog entry documenting all changes

## Implementation Details

- All admonitions use Material for MkDocs syntax (`!!! type "title"`)
- Code annotations use Zensical pattern: `(1)!` in code with numbered explanations below
- Mermaid diagrams use brand colors: `#1F4E79` (warehouse), `#E07A5F` (DuckDB)
- Backlog tracking updated to mark all related items as `done`
- Roadmap updated to reflect completion of v0.0.9 work package

https://claude.ai/code/session_01EF6eDcXRsJtjw9mG3QbYQo